### PR TITLE
Try locally-installed mocha first

### DIFF
--- a/autoload/test/mocha.vim
+++ b/autoload/test/mocha.vim
@@ -25,7 +25,11 @@ function! test#mocha#build_args(args) abort
 endfunction
 
 function! test#mocha#executable() abort
-  return "mocha"
+  if filereadable('node_modules/.bin/mocha')
+    return 'node_modules/.bin/mocha'
+  else
+    return 'mocha'
+  endif
 endfunction
 
 function! test#mocha#nearest_test(position)


### PR DESCRIPTION
If mocha is installed locally (i.e. defined in `package.json` and installed with `npm install`), its executable is not available in `$PATH` by default.
