### PR TITLE
Remove dot-slash for not current directory commands

### DIFF
--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -19,8 +19,8 @@ endfunction
 function! test#ruby#cucumber#executable() abort
   if filereadable('.zeus.sock')
     return 'zeus cucumber'
-  elseif filereadable('./bin/cucumber')
-    return './bin/cucumber'
+  elseif filereadable('bin/cucumber')
+    return 'bin/cucumber'
   elseif filereadable('Gemfile')
     return 'bundle exec cucumber'
   else

--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -51,11 +51,11 @@ endfunction
 
 function! test#ruby#minitest#executable() abort
   if system('cat Rakefile') =~# 'Rake::TestTask' ||
-   \ (exists('b:rails_root') || filereadable('./bin/rails'))
+   \ (exists('b:rails_root') || filereadable('bin/rails'))
     if filereadable('.zeus.sock')
       return 'zeus rake test'
-    elseif filereadable('./bin/rake')
-      return './bin/rake test'
+    elseif filereadable('bin/rake')
+      return 'bin/rake test'
     elseif filereadable('Gemfile')
       return 'bundle exec rake test'
     else

--- a/autoload/test/ruby/rspec.vim
+++ b/autoload/test/ruby/rspec.vim
@@ -19,8 +19,8 @@ endfunction
 function! test#ruby#rspec#executable() abort
   if filereadable('.zeus.sock')
     return 'zeus rspec'
-  elseif filereadable('./bin/rspec')
-    return './bin/rspec'
+  elseif filereadable('bin/rspec')
+    return 'bin/rspec'
   elseif filereadable('Gemfile')
     return 'bundle exec rspec'
   else


### PR DESCRIPTION
It only makes sense to have `./` prefix for commands executed in the same directory. In case of `bin/`, there is not need to prepend them.
