### PR TITLE
Get the current file path before `before_run`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Flavorfile.lock
 .vim-flavor/
 /doc/tags
+*.sw*

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -1,10 +1,11 @@
 function! test#run(type, arguments) abort
+  let current_file = expand('%')
+  let position = s:get_position(current_file)
   call s:before_run()
 
   let alternate_file = s:alternate_file()
 
-  if test#test_file(expand('%'))
-    let position = s:get_position(expand('%'))
+  if test#test_file(current_file)
     let g:test#last_position = position
   elseif !empty(alternate_file) && test#test_file(alternate_file) && (!exists('g:test#last_position') || alternate_file !=# g:test#last_position['file'])
     let position = s:get_position(alternate_file)


### PR DESCRIPTION
The goal of this PR is to mitigate a side effect that happens when using `test#project_root`. Thanks for this project. It's a massive time saver. My apologies for not adding any tests for this PR. I wasn't sure how to test something that was in the `test#run` function.

When `test#project_root` is used, `before_run` has a side effect of
changing `expand('%')` from a relative path to an absolute path. I
suspect this is because of the `execute 'cd'` call.

This side effect can prevent tests from running if the test command is
dependent on the relative path.

For instance, I used the Vagrant transformation listed in the README.
Because my Vagrant VM is in a different directory, I had to add
`test#project_root` to make the `vagrant ssh` call work. With the side
effect occurring, the test in the vagrant ssh connection would fail
because the `position['file']` path was set to the absolute path of the
test file *on my host machine*.

I also had to move the first `get_position` call because `get_position`
tries to compare `a:path` to `expand('%')` to pick the line and column
numbers. If `get_position` is called after `before_run`, then `a:path`
does not match as it should.