### PR TITLE
Make cucumber runner usable for those with non standard features locations

### DIFF
--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -9,6 +9,7 @@ function! test#ruby#cucumber#test_file(file) abort
     else
       let l:featuresDir = finddir('features', test#project_root() . '/**')
       return <SID>has_ruby_children(l:featuresDir)
+    endif
   endif
   return 0
 endfunction

--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -4,8 +4,17 @@ endif
 
 function! test#ruby#cucumber#test_file(file) abort
   if a:file =~# g:test#ruby#cucumber#file_pattern
-    return !empty(glob('features/**/*.rb'))
+    if <SID>has_ruby_children(expand('%:h'))
+      return 1
+    else
+      let l:featuresDir = finddir('features', getcwd() . '/**')
+      return <SID>has_ruby_children(l:featuresDir)
   endif
+  return 0
+endfunction
+
+function! s:has_ruby_children(dir) abort
+  return !empty(glob(a:dir . '/**/*.rb'))
 endfunction
 
 function! test#ruby#cucumber#build_position(type, position) abort

--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -7,7 +7,7 @@ function! test#ruby#cucumber#test_file(file) abort
     if <SID>has_ruby_children(expand('%:h'))
       return 1
     else
-      let l:featuresDir = finddir('features', getcwd() . '/**')
+      let l:featuresDir = finddir('features', test#project_root() . '/**')
       return <SID>has_ruby_children(l:featuresDir)
   endif
   return 0


### PR DESCRIPTION
This change is my solution for https://github.com/janko-m/vim-test/issues/327.

I've slightly modified the approach:

1. First look for any ruby files that are contained in the directory of the current file or any of its children
2. Otherwise, locate the features directory with `finddir` from the project root and do a glob from there.

Step 1. is in my opinion a fairly sensible heuristic which will provide a performance boost as you are not having to glob the entire features directory unless you have to.

