### PR TITLE
Add support for testrunner configuration via vim-projectionist

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,42 @@ You can disable this integration by doing
 let g:test#no_alternate = 1
 ```
 
+It is also possible to configure test runners via projectionist. All you 
+need is to add a `test-runner` key to the projectionist configuration. 
+The value for `test-runner` has to be a dictionary containing the target
+languages as keys and either the name of the runner or an dictionary 
+with additional configuration as value.
+
+Here an example:
+
+```json
+{
+  "gradle/*Test.java": {
+    "test-runner": {
+      "java": {
+        "runner": "gradletest",
+        "options": {
+          'nearest': '--backtrace' 
+        }
+      }
+    }
+  },
+  "mvn/*VerboseTest.java": {
+    "test-runner": {
+      "java": {
+        "runner": "maventest",
+        "options": "--verbose" 
+       }
+    }
+  },
+  "mvn/*Test.java": {
+    "test-runner": {
+      "java": "maventest" 
+    }
+  }
+}
+```
+
 ## Extending
 
 If you wish to extend this plugin with your own test runners, first of all,

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -549,6 +549,42 @@ You can disable this integration by doing
   let g:test#no_alternate = 1
 <
 
+It is also possible to configure test runners via projectionist. All you 
+need is to add a `test-runner` key to the projectionist configuration. 
+The value for `test-runner` has to be a dictionary containing the target
+languages as keys and either the name of the runner or an dictionary 
+with additional configuration as value.
+
+Here an example:
+
+>
+{
+  "gradle/*Test.java": {
+    "test-runner": {
+      "java": {
+        "runner": "gradletest",
+        "options": {
+          'nearest': '--backtrace' 
+        }
+      }
+    }
+  },
+  "mvn/*VerboseTest.java": {
+    "test-runner": {
+      "java": {
+        "runner": "maventest",
+        "options": "--verbose" 
+       }
+    }
+  },
+  "mvn/*Test.java": {
+    "test-runner": {
+      "java": "maventest" 
+    }
+  }
+}
+<
+
 ABOUT                                           *test-about*
 
 You can get the latest version, see the changelog, or report a bug on GitHub:


### PR DESCRIPTION
It is now possible to configure testrunners via a vim-projectionis
configuration file. This allows for an easy per project basis
configuration of your testrunners.

This fixes #406

Make sure these boxes are checked before submitting your pull request:

- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
