### PR TITLE
Fix coloring flag not working on GUI with granular strategies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ before_script:
   - "gem install vim-flavor"
   - "vim-flavor install"
   -
-  - "rvm use 2.5.0 --install --binary --fuzzy"
+  - "rvm use 2.5.8 --install --binary --fuzzy"
 
 script: "vim-flavor test spec/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,15 @@ sudo: false
 rvm:
   - 2.5
 
+cache:
+  directories:
+    - "$HOME/.rvm"
+    - "$HOME/.vvm"
 before_script:
+  - "curl https://raw.githubusercontent.com/kana/vim-version-manager/master/bin/vvm | python - setup; true"
+  - "source ~/.vvm/etc/login"
+  - "vvm update_itself"
+  - "vvm use vimorg--v8.2.0803 --install --with-features=huge"
   - "gem install vim-flavor"
   - "vim-flavor install"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_script:
   - "source ~/.vvm/etc/login"
   - "vvm update_itself"
   - "vvm use vimorg--v8.2.0803 --install --with-features=huge"
-  - "gem install vim-flavor"
-  - "vim-flavor install"
   -
   - "rvm use 2.5.8 --install --binary --fuzzy"
+  - "gem install vim-flavor"
+  - "vim-flavor install"
 
 script: "vim-flavor test spec/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 
 sudo: false
 
-rvm:
-  - 2.5
-
 cache:
   directories:
     - "$HOME/.rvm"
@@ -16,5 +13,7 @@ before_script:
   - "vvm use vimorg--v8.2.0803 --install --with-features=huge"
   - "gem install vim-flavor"
   - "vim-flavor install"
+  -
+  - "rvm use 2.5.0 --install --binary --fuzzy"
 
 script: "vim-flavor test spec/"

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -81,7 +81,7 @@ function! test#execute(runner, args, ...) abort
   call filter(args, '!empty(v:val)')
 
   let executable = test#base#executable(a:runner)
-  let args = test#base#build_args(a:runner, args)
+  let args = test#base#build_args(a:runner, args, strategy)
   let cmd = [executable] + args
   call filter(cmd, '!empty(v:val)')
 

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,8 +30,14 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args) abort
-  return test#{a:runner}#build_args(a:args)
+function! test#base#build_args(runner, args, strategy) abort
+  let no_color = has('gui_running') && strategy ==# 'basic'
+
+  try
+    return test#{a:runner}#build_args(a:args, !no_color)
+  catch /^Vim\%((\a\+)\)\=:E118/ " too many arguments
+    return test#{a:runner}#build_args(a:args)
+  endtry
 endfunction
 
 function! test#base#file_exists(file) abort
@@ -40,11 +46,6 @@ endfunction
 
 function! test#base#escape_regex(string) abort
   return escape(a:string, '?+*\^$.|{}[]()')
-endfunction
-
-function! test#base#no_colors() abort
-  let strategy = get(g:, 'test#strategy', 'basic')
-  return has('gui_running') && strategy ==# 'basic'
 endfunction
 
 " Takes a position and a dictionary of patterns, and returns list of strings

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,7 +30,7 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args, strategy) abort
+function! test#base#build_args(runner, args, strategy)
   let no_color = has('gui_running') && a:strategy ==# 'basic'
 
   try

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,7 +30,7 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args, strategy)
+function! test#base#build_args(runner, args, strategy) abort
   let no_color = has('gui_running') && a:strategy ==# 'basic'
 
   try

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,8 +30,8 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args, strategy) abort
-  let no_color = has('gui_running') && strategy ==# 'basic'
+function! test#base#build_args(runner, args, strategy)
+  let no_color = has('gui_running') && a:strategy ==# 'basic'
 
   try
     return test#{a:runner}#build_args(a:args, !no_color)

--- a/autoload/test/elixir/exunit.vim
+++ b/autoload/test/elixir/exunit.vim
@@ -28,10 +28,10 @@ function! test#elixir#exunit#build_position(type, position) abort
   end
 endfunction
 
-function! test#elixir#exunit#build_args(args) abort
+function! test#elixir#exunit#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -26,10 +26,10 @@ function! test#go#ginkgo#build_position(type, position) abort
   endif
 endfunction
 
-function! test#go#ginkgo#build_args(args) abort
+function! test#go#ginkgo#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--nocolor'] + args
   endif
 

--- a/autoload/test/javascript/ava.vim
+++ b/autoload/test/javascript/ava.vim
@@ -21,10 +21,10 @@ function! test#javascript#ava#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#ava#build_args(args) abort
+function! test#javascript#ava#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -21,10 +21,10 @@ function! test#javascript#jasmine#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#jasmine#build_args(args) abort
+function! test#javascript#jasmine#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -29,14 +29,14 @@ function! test#javascript#karma#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#karma#build_args(args) abort
+function! test#javascript#karma#build_args(args, color) abort
   let args = a:args
 
   " reduce clutter in the output by only reporting tests and only run once so
   " we take less time & therefore annoy the user less
   call extend(args, ['--single-run', '--no-auto-watch', '--log-level=disable'])
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -27,10 +27,10 @@ function! test#javascript#mocha#build_position(type, position) abort
   endif
 endfunction
 
-function! test#javascript#mocha#build_args(args) abort
+function! test#javascript#mocha#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-colors'] + args
     let args = args + ['|', 'sed -e "s///g"']
   endif

--- a/autoload/test/perl/prove.vim
+++ b/autoload/test/perl/prove.vim
@@ -14,7 +14,7 @@ function! test#perl#prove#build_position(type, position) abort
   endif
 endfunction
 
-function! test#perl#prove#build_args(args) abort
+function! test#perl#prove#build_args(args, color) abort
   let args = []
   let test_args = []
 
@@ -32,7 +32,7 @@ function! test#perl#prove#build_args(args) abort
     let args = ['--recurse'] + args
   endif
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--nocolor'] + args
   endif
 

--- a/autoload/test/php/behat.vim
+++ b/autoload/test/php/behat.vim
@@ -20,10 +20,10 @@ function! test#php#behat#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#behat#build_args(args) abort
+function! test#php#behat#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/codeception.vim
+++ b/autoload/test/php/codeception.vim
@@ -22,10 +22,10 @@ function! test#php#codeception#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#codeception#build_args(args) abort
+function! test#php#codeception#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/dusk.vim
+++ b/autoload/test/php/dusk.vim
@@ -19,10 +19,10 @@ function! test#php#dusk#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#dusk#build_args(args) abort
+function! test#php#dusk#build_args(args, color) abort
   let args = a:args
 
-  if !test#base#no_colors()
+  if a:color
     let args = ['--colors'] + args
   endif
 

--- a/autoload/test/php/kahlan.vim
+++ b/autoload/test/php/kahlan.vim
@@ -14,10 +14,10 @@ function! test#php#kahlan#build_position(type, position) abort
   return []
 endfunction
 
-function! test#php#kahlan#build_args(args) abort
+function! test#php#kahlan#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-colors=true'] + args
   endif
 

--- a/autoload/test/php/peridot.vim
+++ b/autoload/test/php/peridot.vim
@@ -18,10 +18,10 @@ function! test#php#peridot#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#peridot#build_args(args) abort
+function! test#php#peridot#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-colors'] + args
   endif
 

--- a/autoload/test/php/pest.vim
+++ b/autoload/test/php/pest.vim
@@ -30,10 +30,10 @@ function! test#php#pest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#pest#build_args(args) abort
+function! test#php#pest#build_args(args, color) abort
   let args = a:args
 
-  if !test#base#no_colors()
+  if a:color
     let args = ['--colors'] + args
   endif
 

--- a/autoload/test/php/phpspec.vim
+++ b/autoload/test/php/phpspec.vim
@@ -17,10 +17,10 @@ function! test#php#phpspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#phpspec#build_args(args) abort
+function! test#php#phpspec#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-ansi'] + args
   endif
 

--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -33,10 +33,10 @@ function! test#php#phpunit#build_position(type, position) abort
   endif
 endfunction
 
-function! test#php#phpunit#build_args(args) abort
+function! test#php#phpunit#build_args(args, color) abort
   let args = a:args
 
-  if !test#base#no_colors()
+  if a:color
     let args = ['--colors'] + args
   endif
 

--- a/autoload/test/python/mamba.vim
+++ b/autoload/test/python/mamba.vim
@@ -27,10 +27,10 @@ function! test#python#mamba#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#mamba#build_args(args) abort
+function! test#python#mamba#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--color=no'] + args
   endif
 

--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -27,10 +27,10 @@ function! test#python#pytest#build_position(type, position) abort
   endif
 endfunction
 
-function! test#python#pytest#build_args(args) abort
+function! test#python#pytest#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--color=no'] + args
   endif
 

--- a/autoload/test/ruby/cucumber.vim
+++ b/autoload/test/ruby/cucumber.vim
@@ -18,10 +18,10 @@ function! test#ruby#cucumber#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#cucumber#build_args(args) abort
+function! test#ruby#cucumber#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/ruby/rspec.vim
+++ b/autoload/test/ruby/rspec.vim
@@ -16,10 +16,10 @@ function! test#ruby#rspec#build_position(type, position) abort
   endif
 endfunction
 
-function! test#ruby#rspec#build_args(args) abort
+function! test#ruby#rspec#build_args(args, color) abort
   let args = a:args
 
-  if test#base#no_colors()
+  if !a:color
     let args = ['--no-color'] + args
   endif
 

--- a/autoload/test/shell/bats.vim
+++ b/autoload/test/shell/bats.vim
@@ -30,7 +30,7 @@ function! test#shell#bats#build_position(type, position) abort
   endif
 endfunction
 
-function! test#shell#bats#build_args(args) abort
+function! test#shell#bats#build_args(args)
   if empty(filter(copy(a:args), 'test#base#file_exists(v:val)'))
     call add(a:args, 'test/')
   endif


### PR DESCRIPTION
The `test#base#no_colors()` function was looking at the global strategy variable, which can be a dictionary when per-granularity strategies was specified. This function doesn't know the granularity, since the `build_args()` runner function is called from `test#execute()`, which doesn't have granularity knowledge (since that function can be called directly via runner commands such as `:RSpec`).

Instead of requiring runners to call into our function for determining whether coloring can be used, we change the code to determine this before calling `build_args()`, and then just pass the boolean value into the function. At that point the strategy has already been resolved, so we can just use it right there and then.

I didn't find a way in VimScript to check how many arguments a function supports, so we had to resort to try/catch for backwards compatibility. We could have updated all runners to accept the second argument, but that wouldn't solve any custom-made runners that people might have created locally.

Closes #429
