### PR TITLE
Use paratest as the phpunit executable if present

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -46,6 +46,8 @@ endfunction
 function! test#php#phpunit#executable() abort
   if filereadable('./artisan')
     return 'php artisan test'
+  elseif filereadable('./vendor/bin/paratest')
+    return './vendor/bin/paratest'
   elseif filereadable('./vendor/bin/phpunit')
     return './vendor/bin/phpunit'
   elseif filereadable('./bin/phpunit')


### PR DESCRIPTION
This resolves #424 with a simpler solution of just using paratest as the phpunit runner executable if present