### PR TITLE
Bugfix for ParaTest nearest

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -25,6 +25,9 @@ function! test#php#phpunit#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name) | let name = '--filter '.shellescape('::'.name, 1) | endif
+    if !empty(name) && filereadable('./vendor/bin/paratest')
+      let name = '--functional '. name
+    endif
     return [name, a:position['file']]
   elseif a:type ==# 'file'
     return [a:position['file']]

--- a/spec/paratest_spec.vim
+++ b/spec/paratest_spec.vim
@@ -1,0 +1,44 @@
+source spec/support/helpers.vim
+
+describe "ParaTest"
+
+  before
+    cd spec/fixtures/phpunit
+    !mkdir vendor
+    !mkdir vendor/bin
+    !touch vendor/bin/paratest
+  end
+
+  after
+    !rm -f vendor/bin/*
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    !touch vendor/bin/paratest
+    view NormalTest.php
+    TestFile
+
+    Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
+  end
+
+  it "runs test suites"
+    view NormalTest.php
+    TestSuite
+
+    Expect g:test#last_command == './vendor/bin/paratest --colors'
+  end
+
+  it "runs in functional mode for TestNearest with --filter"
+    view +1 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "./vendor/bin/paratest --colors NormalTest.php"
+
+    view +9 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "./vendor/bin/paratest --colors --functional --filter '::testShouldAddTwoNumbers' NormalTest.php"
+  end
+end

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -98,11 +98,11 @@ describe "PHPUnit"
     Expect g:test#last_command == 'php artisan test --colors NormalTest.php'
   end
 
-	describe "when paratest installed in vendor/bin"
+  describe "when paratest installed in vendor/bin"
 
-		before
+    before
       !touch vendor/bin/paratest
-		end
+    end
 
     it "uses paratest for TestFile"
       !touch vendor/bin/paratest
@@ -132,6 +132,6 @@ describe "PHPUnit"
       Expect g:test#last_command == "./vendor/bin/paratest --colors --functional --filter '::testShouldAddTwoNumbers' NormalTest.php"
     end
 
-	end
+  end
 
 end

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -98,13 +98,13 @@ describe "PHPUnit"
     Expect g:test#last_command == 'php artisan test --colors NormalTest.php'
   end
 
-  describe "when paratest installed in vendor/bin"
+  describe "when paratest is installed in vendor/bin"
 
     before
       !touch vendor/bin/paratest
     end
 
-    it "uses paratest for TestFile"
+    it "executes paratest for TestFile"
       !touch vendor/bin/paratest
       view NormalTest.php
       TestFile
@@ -112,15 +112,14 @@ describe "PHPUnit"
       Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
     end
 
-
-    it "uses paratest for TestSuite"
+    it "executes paratest for TestSuite"
       view NormalTest.php
       TestSuite
 
       Expect g:test#last_command == './vendor/bin/paratest --colors'
     end
 
-    it "runs paratest in functional mode for TestNearest with --filter"
+    it "executes paratest in functional mode for TestNearest with --filter"
       view +1 NormalTest.php
       TestNearest
 

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -112,6 +112,26 @@ describe "PHPUnit"
       Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
     end
 
+
+    it "uses paratest for TestSuite"
+      view NormalTest.php
+      TestSuite
+
+      Expect g:test#last_command == './vendor/bin/paratest --colors'
+    end
+
+    it "runs paratest in functional mode for TestNearest with --filter"
+      view +1 NormalTest.php
+      TestNearest
+
+      Expect g:test#last_command == "./vendor/bin/paratest --colors NormalTest.php"
+
+      view +9 NormalTest.php
+      TestNearest
+
+      Expect g:test#last_command == "./vendor/bin/paratest --colors --functional --filter '::testShouldAddTwoNumbers' NormalTest.php"
+    end
+
 	end
 
 end

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -4,13 +4,10 @@ describe "PHPUnit"
 
   before
     cd spec/fixtures/phpunit
-    !mkdir vendor
-    !mkdir vendor/bin
   end
 
   after
     !rm -f artisan
-    !rm -f vendor/bin/*
     call Teardown()
     cd -
   end

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -4,13 +4,13 @@ describe "PHPUnit"
 
   before
     cd spec/fixtures/phpunit
-	!mkdir vendor
-	!mkdir vendor/bin
+    !mkdir vendor
+    !mkdir vendor/bin
   end
 
   after
-	!rm -f artisan
-	!rm -f vendor/bin/*
+    !rm -f artisan
+    !rm -f vendor/bin/*
     call Teardown()
     cd -
   end
@@ -98,12 +98,20 @@ describe "PHPUnit"
     Expect g:test#last_command == 'php artisan test --colors NormalTest.php'
   end
 
-  it "uses paratest if present"
-    !touch vendor/bin/paratest
-    view NormalTest.php
-    TestFile
+	describe "when paratest installed in vendor/bin"
 
-    Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
-  end
+		before
+      !touch vendor/bin/paratest
+		end
+
+    it "uses paratest for TestFile"
+      !touch vendor/bin/paratest
+      view NormalTest.php
+      TestFile
+
+      Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
+    end
+
+	end
 
 end

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -98,39 +98,4 @@ describe "PHPUnit"
     Expect g:test#last_command == 'php artisan test --colors NormalTest.php'
   end
 
-  describe "when paratest is installed in vendor/bin"
-
-    before
-      !touch vendor/bin/paratest
-    end
-
-    it "executes paratest for TestFile"
-      !touch vendor/bin/paratest
-      view NormalTest.php
-      TestFile
-
-      Expect g:test#last_command == './vendor/bin/paratest --colors NormalTest.php'
-    end
-
-    it "executes paratest for TestSuite"
-      view NormalTest.php
-      TestSuite
-
-      Expect g:test#last_command == './vendor/bin/paratest --colors'
-    end
-
-    it "executes paratest in functional mode for TestNearest with --filter"
-      view +1 NormalTest.php
-      TestNearest
-
-      Expect g:test#last_command == "./vendor/bin/paratest --colors NormalTest.php"
-
-      view +9 NormalTest.php
-      TestNearest
-
-      Expect g:test#last_command == "./vendor/bin/paratest --colors --functional --filter '::testShouldAddTwoNumbers' NormalTest.php"
-    end
-
-  end
-
 end


### PR DESCRIPTION
This fixes the following issue:

> when executing `TestNearest` now throws `Option --filter is not implemented for non functional mode` because of paratest.
 
 _Originally posted by @vivoconunxino in https://github.com/vim-test/vim-test/pull/471#issuecomment-636066013_