### PR TITLE
Fix exec when script path needs escaping (#482)

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -192,7 +192,7 @@ endfunction
 
 function! s:execute_script(name, cmd) abort
   let script_path = g:test#plugin_path . '/bin/' . a:name
-  let cmd = join([script_path, shellescape(a:cmd)])
+  let cmd = join([shellescape(script_path), shellescape(a:cmd)])
   execute 'silent !'.cmd
 endfunction
 


### PR DESCRIPTION
Previously, if a script existed in a directory whose path contained parentheses,
any strategies relying on `execute_script` would silently fail because the script path
was not escaped.

This fixes the issue by wrapping the path with `shellescape`.

Make sure these boxes are checked before submitting your pull request:

- [NA] Add fixtures and spec when implementing or updating a test runner
- [NA] Update the README accordingly
- [NA] Update the Vim documentation in `doc/test.txt`
