### PR TITLE
Fix readme for kitty strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ please make sure:
 - you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
 
   ```
-  $ export KITTY_LISTEN_ON=/tmp/mykitty
+  $ export KITTY_LISTEN_ON=unix:/tmp/mykitty
   ```
 
 ### Shtuff strategy setup

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -393,7 +393,7 @@ Please make sure:
 <
 - you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
 >
-  $ export KITTY_LISTEN_ON=/tmp/mykitty
+  $ export KITTY_LISTEN_ON=unix:/tmp/mykitty
 <
 You can then use this strategy this way:
 >


### PR DESCRIPTION
Previously, the documentation omitted the protocol for kitty's port, which silently broke the strategy.

Kitty splits the listen-on port by ':', which you can see here:
https://github.com/kovidgoyal/kitty/blob/a0d6445dda1a466b6be7916d2264c55a2960e13c/kitty/utils.py#L382

We need to set `KITTY_LISTEN_ON=unix:/tmp/mykitty` to prevent an argument error a bit further down from this line.

Make sure these boxes are checked before submitting your pull request:

- [NA] Add fixtures and spec when implementing or updating a test runner
- [✓] Update the README accordingly
- [✓] Update the Vim documentation in `doc/test.txt`
