### PR TITLE
Add docs for using kitty via kitty.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,25 @@ please make sure:
   $ kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
   ```
 
+  or via `kitty.conf`:
+
+  ```
+  allow_remote_control yes
+  listen_on unix:/tmp/mykitty
+  ```
+
 - you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
 
   ```
   $ export KITTY_LISTEN_ON=/tmp/mykitty
   ```
+
+  or if via `kitty.conf` (it appends kitty's PID):
+
+  ```
+  $ export KITTY_LISTEN_ON=unix:/tmp/mykitty-$PPID
+  ```
+
 
 ### Shtuff strategy setup
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -391,9 +391,18 @@ Please make sure:
 >
   $ kitty -o allow_remote_control=yes --listen-on unix:/tmp/mykitty
 <
+  or via `kitty.conf`:
+>
+  allow_remote_control yes
+  listen_on unix:/tmp/mykitty
+<
 - you export an environment variable `$KITTY_LISTEN_ON` with the same socket, like:
 >
   $ export KITTY_LISTEN_ON=/tmp/mykitty
+<
+  or if via `kitty.conf` (it appends kitty's PID):
+>
+  $ export KITTY_LISTEN_ON=unix:/tmp/mykitty-$PPID
 <
 You can then use this strategy this way:
 >


### PR DESCRIPTION
The previous documentation for kitty assumed launching via commands.
When using kitty.conf, the logistics are a bit different. This updates
the documentation for using `kitty.conf` as well.

Make sure these boxes are checked before submitting your pull request:

- [NA] Add fixtures and spec when implementing or updating a test runner
- [✓] Update the README accordingly
- [✓] Update the Vim documentation in `doc/test.txt`
