### PR TITLE
Remove logic for using artisan test in PHPUnit runner

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -47,9 +47,7 @@ function! test#php#phpunit#build_args(args, color) abort
 endfunction
 
 function! test#php#phpunit#executable() abort
-  if filereadable('./artisan')
-    return 'php artisan test'
-  elseif filereadable('./vendor/bin/paratest')
+  if filereadable('./vendor/bin/paratest')
     return './vendor/bin/paratest'
   elseif filereadable('./vendor/bin/phpunit')
     return './vendor/bin/phpunit'

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -7,7 +7,6 @@ describe "PHPUnit"
   end
 
   after
-    !rm -f artisan
     call Teardown()
     cd -
   end
@@ -85,14 +84,6 @@ describe "PHPUnit"
     TestFile
 
     Expect exists('g:test#last_command') == 0
-  end
-
-  it "uses Laravel's artisan command if present"
-    !touch artisan
-    view NormalTest.php
-    TestFile
-
-    Expect g:test#last_command == 'php artisan test --colors NormalTest.php'
   end
 
 end


### PR DESCRIPTION
Remove logic for using artisan test in PHPUnit runner as per https://github.com/vim-test/vim-test/issues/445#issuecomment-646032763 closes #445 