### PR TITLE
doc: Update help file to replace old url references with new url

### DIFF
--- a/doc/test.txt
+++ b/doc/test.txt
@@ -594,7 +594,7 @@ ABOUT                                           *test-about*
 
 You can get the latest version, see the changelog, or report a bug on GitHub:
 
-https://github.com/janko-m/vim-test
+https://github.com/vim-test/vim-test
 
 
 CREDITS                                         *test-credits*


### PR DESCRIPTION
- [x] Update the Vim documentation in `doc/test.txt`

I found an old url in help file, so I fixed it.