### PR TITLE
Fixs dotnet test nearest

### DIFF
--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -19,12 +19,12 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return [project_path, '--filter', 'FullyQualifiedName\~' . name]
+      return [project_path, '--filter', 'FullyQualifiedName=' . name]
     else
-      return [project_path, '--filter', 'FullyQualifiedName\~' . filename]
+      return [project_path, '--filter', 'FullyQualifiedName=' . filename]
     endif
   elseif a:type ==# 'file'
-    return [project_path,  '--filter', 'FullyQualifiedName\~' . filename]
+    return [project_path,  '--filter', 'FullyQualifiedName=' . filename]
   else
     return [project_path]
   endif

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -20,25 +20,25 @@ describe "DotnetTest"
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests'
 
     view +8 Tests.cs
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests.TestAsync'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests.TestAsync'
 
     view +14 Tests.cs
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests.Test'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests.Test'
 
     view +20 Tests.cs
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Namespace.Tests.TestAsyncWithTaskReturn'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests.TestAsyncWithTaskReturn'
 
   end
 
@@ -48,7 +48,7 @@ describe "DotnetTest"
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Tests'
   end
 
   it "runs file tests"
@@ -56,7 +56,7 @@ describe "DotnetTest"
     TestFile
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName\~Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Tests'
   end
 
   it "runs test suites"


### PR DESCRIPTION
I ran into issues with the current dotnet test runner which didn't allow me to use test nearest and this is a quick fix for it

Make sure these boxes are checked before submitting your pull request:

- [X ] Add fixtures and spec when implementing or updating a test runner
- [X ] Update the README accordingly
- [X ] Update the Vim documentation in `doc/test.txt`
