### PR TITLE
Javascript runner can be specified when package.json has multiple runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,10 @@ let test#ruby#use_spring_binstub = 1
 
 #### JavaScript
 
-Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies.
+Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies. And now you can specify a runner when hava multiple runners listed in package.json dependencies. 
+```vim
+let g:test#javascript#runner = 'jest'
+```
 
 #### Haskell
 

--- a/README.md
+++ b/README.md
@@ -498,7 +498,8 @@ let test#ruby#use_spring_binstub = 1
 
 #### JavaScript
 
-Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies. And now you can specify a runner when hava multiple runners listed in package.json dependencies. 
+Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies. When you have multiple runners listed in the package.json dependencies you can specify a runner like so:
+
 ```vim
 let g:test#javascript#runner = 'jest'
 ```

--- a/autoload/test/javascript/ava.vim
+++ b/autoload/test/javascript/ava.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#ava#file_pattern')
 endif
 
 function! test#javascript#ava#test_file(file) abort
-  return a:file =~# g:test#javascript#ava#file_pattern
-    \ && test#javascript#has_package('ava')
+  if a:file =~# g:test#javascript#ava#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'ava'
+      else
+        return test#javascript#has_package('ava')
+      endif
+  endif
 endfunction
 
 function! test#javascript#ava#build_position(type, position) abort

--- a/autoload/test/javascript/cucumberjs.vim
+++ b/autoload/test/javascript/cucumberjs.vim
@@ -3,9 +3,6 @@ if !exists('g:test#javascript#cucumberjs#file_pattern')
 endif
 
 function! test#javascript#cucumberjs#test_file(file) abort
-  "if a:file =~# g:test#javascript#cucumberjs#file_pattern
-    "return test#javascript#has_package('cucumber')
-  "endif
   if a:file =~# g:test#javascript#cucumberjs#file_pattern
       if exists('g:test#javascript#runner')
           return g:test#javascript#runner ==# 'cucumber'

--- a/autoload/test/javascript/cucumberjs.vim
+++ b/autoload/test/javascript/cucumberjs.vim
@@ -3,8 +3,15 @@ if !exists('g:test#javascript#cucumberjs#file_pattern')
 endif
 
 function! test#javascript#cucumberjs#test_file(file) abort
+  "if a:file =~# g:test#javascript#cucumberjs#file_pattern
+    "return test#javascript#has_package('cucumber')
+  "endif
   if a:file =~# g:test#javascript#cucumberjs#file_pattern
-    return test#javascript#has_package('cucumber')
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'cucumber'
+      else
+        return test#javascript#has_package('cucumber')
+      endif
   endif
 endfunction
 

--- a/autoload/test/javascript/cypress.vim
+++ b/autoload/test/javascript/cypress.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#cypress#file_pattern')
 endif
 
 function! test#javascript#cypress#test_file(file) abort
-  return a:file =~# g:test#javascript#cypress#file_pattern
-    \ && test#javascript#has_package('cypress')
+  if a:file =~# g:test#javascript#cypress#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'cypress'
+      else
+        return test#javascript#has_package('cypress')
+      endif
+  endif
 endfunction
 
 function! test#javascript#cypress#build_position(type, position) abort

--- a/autoload/test/javascript/denotest.vim
+++ b/autoload/test/javascript/denotest.vim
@@ -3,9 +3,14 @@ if !exists('g:test#javascript#denotest#file_pattern')
 endif
 
 function! test#javascript#denotest#test_file(file) abort
-  return a:file =~# g:test#javascript#denotest#file_pattern
-    \ && !filereadable('package.json')
-    \ && !empty(filter(readfile(a:file), 'v:val =~# ''Deno.test('''))
+  if a:file =~# g:test#javascript#denotest#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'denotest'
+      else
+        return !filereadable('package.json')
+                    \ && !empty(filter(readfile(a:file), 'v:val =~# ''Deno.test('''))
+      endif
+  endif
 endfunction
 
 function! test#javascript#denotest#build_position(type, position) abort

--- a/autoload/test/javascript/intern.vim
+++ b/autoload/test/javascript/intern.vim
@@ -11,9 +11,14 @@ if !exists('g:test#javascript#intern#config_module')
 endif
 
 function! test#javascript#intern#test_file(file) abort
-  return a:file =~# g:test#javascript#intern#file_pattern
-    \ && filereadable(g:test#javascript#intern#config_module . '.js')
-    \ && test#javascript#has_package('intern')
+  if a:file =~# g:test#javascript#intern#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'intern'
+      else
+        return test#javascript#has_package('intern')
+                    \&& filereadable(g:test#javascript#intern#config_module . '.js')
+      endif
+  endif
 endfunction
 
 function! test#javascript#intern#build_position(type, position) abort

--- a/autoload/test/javascript/jasmine.vim
+++ b/autoload/test/javascript/jasmine.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#jasmine#file_pattern')
 endif
 
 function! test#javascript#jasmine#test_file(file) abort
-  return a:file =~? g:test#javascript#jasmine#file_pattern
-    \ && test#javascript#has_package('jasmine')
+  if a:file =~? g:test#javascript#jasmine#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'jasmine'
+      else
+        return test#javascript#has_package('jasmine')
+      endif
+  endif
 endfunction
 
 function! test#javascript#jasmine#build_position(type, position) abort

--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#jest#file_pattern')
 endif
 
 function! test#javascript#jest#test_file(file) abort
-  return a:file =~# g:test#javascript#jest#file_pattern
-    \ && test#javascript#has_package('jest')
+  if a:file =~# g:test#javascript#jest#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'jest'
+      else
+        return test#javascript#has_package('jest')
+      endif
+  endif
 endfunction
 
 function! test#javascript#jest#build_position(type, position) abort

--- a/autoload/test/javascript/karma.vim
+++ b/autoload/test/javascript/karma.vim
@@ -3,9 +3,14 @@ if !exists('g:test#javascript#karma#file_pattern')
 endif
 
 function! test#javascript#karma#test_file(file) abort
-  return a:file =~? g:test#javascript#karma#file_pattern
-    \ && test#javascript#has_package('karma')
-    \ && !test#javascript#has_package('@angular/cli')
+  if a:file =~? g:test#javascript#karma#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'karma'
+      else
+        return test#javascript#has_package('karma')
+                    \&& !test#javascript#has_package('@angular/cli')
+      endif
+  endif
 endfunction
 
 function! test#javascript#karma#build_position(type, position) abort

--- a/autoload/test/javascript/lab.vim
+++ b/autoload/test/javascript/lab.vim
@@ -4,13 +4,17 @@ endif
 
 function! test#javascript#lab#test_file(file) abort
   if a:file =~# g:test#javascript#lab#file_pattern
-    for line in readfile(a:file)
-      let pattern = '\v[Ll]ab.script\(\)'
-      if line =~# pattern
-        return 1
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'lab'
+      else
+        for line in readfile(a:file)
+          let pattern = '\v[Ll]ab.script\(\)'
+          if line =~# pattern
+            return 1
+          endif
+        endfor
+        return 0
       endif
-    endfor
-    return 0
   endif
 endfunction
 

--- a/autoload/test/javascript/mocha.vim
+++ b/autoload/test/javascript/mocha.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#mocha#file_pattern')
 endif
 
 function! test#javascript#mocha#test_file(file) abort
-  return a:file =~# g:test#javascript#mocha#file_pattern
-    \ && test#javascript#has_package('mocha')
+  if a:file =~# g:test#javascript#mocha#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'mocha'
+      else
+        return test#javascript#has_package('mocha')
+      endif
+  endif
 endfunction
 
 function! test#javascript#mocha#build_position(type, position) abort

--- a/autoload/test/javascript/ngtest.vim
+++ b/autoload/test/javascript/ngtest.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#ngtest#file_pattern')
 endif
 
 function! test#javascript#ngtest#test_file(file) abort
-  return a:file =~# g:test#javascript#ngtest#file_pattern
-    \ && test#javascript#has_package('@angular/cli')
+  if a:file =~# g:test#javascript#ngtest#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'ngtest'
+      else
+        return test#javascript#has_package('@angular/cli')
+      endif
+  endif
 endfunction
 
 function! test#javascript#ngtest#build_args(args) abort

--- a/autoload/test/javascript/reactscripts.vim
+++ b/autoload/test/javascript/reactscripts.vim
@@ -3,8 +3,13 @@ if !exists('g:test#javascript#reactscripts#file_pattern')
 endif
 
 function! test#javascript#reactscripts#test_file(file) abort
-  return a:file =~# g:test#javascript#reactscripts#file_pattern
-    \ && test#javascript#has_package('react-scripts')
+  if a:file =~# g:test#javascript#reactscripts#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'reactscripts'
+      else
+        return test#javascript#has_package('react-scripts')
+      endif
+  endif
 endfunction
 
 function! test#javascript#reactscripts#build_position(type, position) abort

--- a/autoload/test/javascript/tap.vim
+++ b/autoload/test/javascript/tap.vim
@@ -11,8 +11,13 @@ if !exists('g:test#javascript#tap#reporters')
 endif
 
 function! test#javascript#tap#test_file(file) abort
-  return a:file =~# g:test#javascript#tap#file_pattern 
-        \ && test#javascript#has_package('tap')
+  if a:file =~# g:test#javascript#tap#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'tap'
+      else
+        return test#javascript#has_package('tap')
+      endif
+  endif
 endfunction
 
 function! test#javascript#tap#build_position(type, position) abort

--- a/autoload/test/javascript/webdriverio.vim
+++ b/autoload/test/javascript/webdriverio.vim
@@ -3,9 +3,17 @@ if !exists('g:test#javascript#webdriverio#file_pattern')
 endif
 
 function! test#javascript#webdriverio#test_file(file) abort
-  return a:file =~# g:test#javascript#webdriverio#file_pattern
-    \ && test#javascript#has_package('webdriverio')
-    \ && !empty(glob('wdio.conf.js'))
+  "return a:file =~# g:test#javascript#webdriverio#file_pattern
+    "\ && test#javascript#has_package('webdriverio')
+    "\ && !empty(glob('wdio.conf.js'))
+  if a:file =~# g:test#javascript#webdriverio#file_pattern
+      if exists('g:test#javascript#runner')
+          return g:test#javascript#runner ==# 'webdriverio'
+      else
+        return test#javascript#has_package('webdriverio')
+                    \ && !empty(glob('wdio.conf.js'))
+      endif
+  endif
 endfunction
 
 function! test#javascript#webdriverio#build_position(type, position) abort

--- a/autoload/test/javascript/webdriverio.vim
+++ b/autoload/test/javascript/webdriverio.vim
@@ -3,9 +3,6 @@ if !exists('g:test#javascript#webdriverio#file_pattern')
 endif
 
 function! test#javascript#webdriverio#test_file(file) abort
-  "return a:file =~# g:test#javascript#webdriverio#file_pattern
-    "\ && test#javascript#has_package('webdriverio')
-    "\ && !empty(glob('wdio.conf.js'))
   if a:file =~# g:test#javascript#webdriverio#file_pattern
       if exists('g:test#javascript#runner')
           return g:test#javascript#runner ==# 'webdriverio'

--- a/spec/fixtures/js_multiple/__tests__/normal-test.js
+++ b/spec/fixtures/js_multiple/__tests__/normal-test.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  describe(`Addition`, function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});

--- a/spec/fixtures/js_multiple/package.json
+++ b/spec/fixtures/js_multiple/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "jest": "^20.0.0",
+    "mocha": "^3.3.0",
+    "cypress": "^3.4.1",
+    "ava": "^0.24.0"
+  }
+}

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -134,7 +134,7 @@ describe "Maven Junit3 multimodule tests"
     view sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestSuite -X -f pom.xml -DcustomProperty=5
 
-    Expect g:test#last_command == 'mvn test -X -f pom.xml -DcustomProperty=5  -pl sample_module' 
+    Expect g:test#last_command == 'mvn test -X -f pom.xml -DcustomProperty=5  -pl sample_module'
   end
 
 end

--- a/spec/specify_js_runner_spec.vim
+++ b/spec/specify_js_runner_spec.vim
@@ -1,6 +1,6 @@
 source spec/support/helpers.vim
 
-describe "Runner"
+describe "Multiple JavaScript runners"
 
   before
     cd spec/fixtures/js_multiple

--- a/spec/specify_js_runner_spec.vim
+++ b/spec/specify_js_runner_spec.vim
@@ -1,0 +1,32 @@
+source spec/support/helpers.vim
+
+describe "Runner"
+
+  before
+    cd spec/fixtures/js_multiple
+  end
+
+  it "if not be specified it will return first matched runner"
+    view +1 __tests__/normal-test.js
+    normal O
+    TestNearest
+
+    Expect g:test#last_command == 'mocha __tests__/normal-test.js'
+  end
+
+  it "can be specified when js has multiple runners"
+    let g:test#javascript#runner = 'jest'
+    view +1 __tests__/normal-test.js
+    normal O
+    TestNearest
+
+    Expect g:test#last_command == 'jest --no-coverage -- __tests__/normal-test.js'
+    unlet g:test#javascript#runner
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+end


### PR DESCRIPTION
#### JavaScript

Test runner detection for JavaScript works by checking which runner is listed in the package.json dependencies. If you have globally installed the runner make sure it's also listed in the dependencies. And now you can specify a runner when hava multiple runners listed in package.json dependencies. 
```vim
let g:test#javascript#runner = 'jest'
```

and fix a warning

not ok 16 - Maven Junit3 multimodule tests runs a test suite with user provided options
 {example}，第 4 行
 Vim(call):E488: Trailing characters:
spec/maventest_spec.vim .......... Failed 1/28 subtests

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
