### PR TITLE
Specify a language runner custom strategy to make test have more fun!

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,26 @@ let g:test#custom_strategies = {'echo': function('EchoStrategy')}
 let g:test#strategy = 'echo'
 ```
 
+You can even specify a language runner custom strategy and a test#strategy like this,
+but the language#runner#strategy has higher priority then test#strategy, You can see
+the spec/specify_language_runner_strategy_spec.vim test to see more detail.
+
+```vim
+
+function! EchoStrategy(cmd)
+  echo 'It works! Command for running tests: ' . a:cmd
+endfunction
+
+function! MochaServerStrategy(cmd)
+  let g:channel = sockconnect('tcp', 'localhost:40123')
+  call chansend(g:channel, a:cmd)
+endfunction
+
+let g:test#custom_strategies = {'echo': function('EchoStrategy'), 'MochaServer': function('MochaServerStrategy')}
+let g:test#strategy = 'echo'
+let g:test#javascript#mocha#strategy = 'MochaServer'
+```
+
 ## Transformations
 
 You can automatically apply transformations of your test commands by

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -104,7 +104,12 @@ function! test#shell(cmd, strategy) abort
     let strategy = a:strategy
   endif
 
-  if has_key(g:test#custom_strategies, strategy)
+  let runner = test#determine_runner(expand('%'))
+  let specified_strategy = 'g:test#' . runner . '#strategy'
+
+  if exists('{specified_strategy}')
+    call g:test#custom_strategies[{specified_strategy}](cmd)
+  elseif has_key(g:test#custom_strategies, strategy)
     call g:test#custom_strategies[strategy](cmd)
   else
     call test#strategy#{strategy}(cmd)

--- a/spec/specify_language_runner_strategy_spec.vim
+++ b/spec/specify_language_runner_strategy_spec.vim
@@ -1,0 +1,57 @@
+source spec/support/helpers.vim
+
+describe "Language runner strategy"
+
+  before
+    cd spec/fixtures/jest
+
+    function! TermStrategy(cmd)
+        let g:test#last_command = 'test#strategy worked!'
+    endfunction
+
+    function! JsTermStrategy(cmd)
+        let g:test#last_command = 'specified language runner strategy worked!'
+    endfunction
+  end
+
+  after
+    unlet g:test#last_command
+    call Teardown()
+    cd -
+  end
+
+  it "can be specified and work fine"
+    let g:test#custom_strategies = {'jsTermOpen': function('JsTermStrategy')}
+    let g:test#javascript#jest#strategy = 'jsTermOpen'
+
+    view +1 __tests__/normal-test.js
+    TestNearest
+
+    Expect g:test#last_command == 'specified language runner strategy worked!'
+    unlet g:test#javascript#jest#strategy 
+  end
+
+  it 'if not be specified, test#strategy will work'
+    let g:test#custom_strategies = {'termOpen': function('TermStrategy')}
+    let g:test#strategy = 'termOpen'
+
+    view +1 __tests__/normal-test.js
+    TestNearest
+
+    Expect g:test#last_command == 'test#strategy worked!'
+  end
+
+  it "has higher priority then test#strategy"
+    let g:test#custom_strategies = {'termOpen': function('TermStrategy'), 'jsTermOpen': function('JsTermStrategy')}
+    let g:test#javascript#jest#strategy = 'jsTermOpen'
+
+    view +1 __tests__/normal-test.js
+    TestNearest
+    Expect g:test#last_command == 'specified language runner strategy worked!'
+
+    let g:test#strategy = 'termOpen'
+    TestNearest
+    Expect g:test#last_command == 'specified language runner strategy worked!'
+    unlet g:test#javascript#jest#strategy 
+  end
+end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`

Specify a language runner strategy is so awesome. We made a mochaServer test runner, it will listen on localhost:40123. when test command is received. mochaServer will run the command in 100ms. no waiting start mocha time.

Master please help me finish the `doc/test.txt', I am not good at this. even i can TDD these  code.