### PR TITLE
cargotest: Add support for async tokio tests

### DIFF
--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -4,14 +4,14 @@ endif
 
 if !exists('g:test#rust#cargotest#test_patterns')
   let g:test#rust#cargotest#test_patterns = {
-        \ 'test': ['\v(#\[test\])'],
+        \ 'test': ['\v(#\[%(tokio::)?test\])'],
         \ 'namespace': ['\vmod (tests?)']
     \ }
 endif
 
 if !exists('g:test#rust#cargotest#patterns')
   let g:test#rust#cargotest#patterns = {
-        \ 'test': ['\v\s*fn\s+(\w+)'],
+        \ 'test': ['\v\s*%(async )?fn\s+(\w+)'],
         \ 'namespace': []
     \ }
 endif
@@ -51,11 +51,11 @@ function! test#rust#cargotest#executable() abort
 endfunction
 
 function! s:nearest_test(position) abort
-  " Search backward for the first '#[test]'
+  " Search backward for the first test pattern (usually '#[test]')
   let name = test#base#nearest_test(a:position, g:test#rust#cargotest#test_patterns)
 
-  " If we didn't find the '#[test]' return empty
-  if empty(name['test']) || '#[test]' != name['test'][0]
+  " If we didn't find the '#[test]' attribute, return empty
+  if empty(name['test']) || name['test'][0] !~ '#\[.*\]'
     return ''
   endif
 

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -128,5 +128,11 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test'
   end
 
+  it "supports async tokio tests"
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --exact'
+  end
+
 end
 

--- a/spec/fixtures/cargo/src/lib.rs
+++ b/spec/fixtures/cargo/src/lib.rs
@@ -10,4 +10,8 @@ mod tests {
     #[test]
     fn third_test () {
     }
+
+    #[tokio::test]
+    async fn tokio_async_test() {
+    }
 }


### PR DESCRIPTION
Regular Rust tests look like this...

    #[test]
    fn foo_test() {
    }

...while async Tokio tests look like this.

    #[tokio::test]
    async fn foo_test() {
    }

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] ~Update the README accordingly~
- [ ] ~Update the Vim documentation in `doc/test.txt`~
