### PR TITLE
cargotest: Add support for rstest

### DIFF
--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -4,7 +4,7 @@ endif
 
 if !exists('g:test#rust#cargotest#test_patterns')
   let g:test#rust#cargotest#test_patterns = {
-        \ 'test': ['\v(#\[%(tokio::)?test\])'],
+        \ 'test': ['\v(#\[%(tokio::|rs)?test)'],
         \ 'namespace': ['\vmod (tests?)']
     \ }
 endif
@@ -55,7 +55,7 @@ function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#rust#cargotest#test_patterns)
 
   " If we didn't find the '#[test]' attribute, return empty
-  if empty(name['test']) || name['test'][0] !~ '#\[.*\]'
+  if empty(name['test']) || name['test'][0] !~ '#\[.*'
     return ''
   endif
 

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -134,5 +134,11 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --exact'
   end
 
+  it "supports rstest tests"
+    view +22 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --exact'
+  end
+
 end
 

--- a/spec/fixtures/cargo/src/lib.rs
+++ b/spec/fixtures/cargo/src/lib.rs
@@ -14,4 +14,11 @@ mod tests {
     #[tokio::test]
     async fn tokio_async_test() {
     }
+
+    #[rstest(input,
+        case(1),
+        case(2),
+    )]
+    fn rstest_test(_: u8) {
+    }
 }


### PR DESCRIPTION
- [x] Add fixtures and spec when implementing or updating a test runner
- [x] ~Update the README accordingly~
- [x] ~Update the Vim documentation in `doc/test.txt`~

Added support for [rstest](https://github.com/la10736/rstest)

Note: Removed the `\]` on the pattern check as these attributes can be multi-line
