### PR TITLE
Conditionally prefix pyunit command with pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,9 @@ let test#python#runner = 'pytest'
 The pytest runner optionally supports [pipenv](https://github.com/pypa/pipenv).
 If you have a `Pipfile`, it will use `pipenv run pytest` instead of just
 `pytest`. It also supports [poetry](https://github.com/sdispater/poetry)
-and will use `poetry run pytest` if it detects a `poetry.lock`.
+and will use `poetry run pytest` if it detects a `poetry.lock`. The pyunit
+runner supports [pipenv](https://github.com/pypa/pipenv) as well and will
+use `pipenv run python -m unittest` if there is a `Pipfile`.
 
 #### Java
 

--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -33,7 +33,13 @@ function! test#python#pyunit#build_args(args) abort
 endfunction
 
 function! test#python#pyunit#executable() abort
-  return 'python -m unittest'
+  let pipenv_prefix = ""
+
+  if filereadable("Pipfile")
+    let pipenv_prefix = "pipenv run "
+  endif
+
+  return pipenv_prefix . 'python -m unittest'
 endfunction
 
 function! s:get_import_path(filepath) abort

--- a/spec/pyunit_pipenv_spec.vim
+++ b/spec/pyunit_pipenv_spec.vim
@@ -1,0 +1,36 @@
+source spec/support/helpers.vim
+
+describe "PyUnit with Pipenv"
+
+  before
+    let g:test#python#runner = 'pyunit'
+    cd spec/fixtures/pytest_pipenv
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest tests"
+    view +1 test_class.py
+    TestNearest
+
+    Expect g:test#last_command == 'pipenv run python -m unittest test_class.TestNumbers'
+  end
+
+  it "runs file tests"
+    view test_class.py
+    TestFile
+
+    Expect g:test#last_command == 'pipenv run python -m unittest test_class'
+  end
+
+  it "runs test suites"
+    view test_class.py
+    TestSuite
+
+    Expect g:test#last_command == 'pipenv run python -m unittest'
+  end
+
+end


### PR DESCRIPTION
This change prefixes the pyunit command with 'pipenv run' if it
finds a Pipfile.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
