### PR TITLE
Fix cargo test invocation for main.rs

### DIFF
--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -88,9 +88,9 @@ function! s:test_namespace(filename) abort
   " On a normal cargo project, the first item is 'src'
   let l:modules = split(l:path, '/')
 
-  " 'src/lib.rs' and 'src/some/mod.rs' does not end
+  " 'src/main.rs', 'src/lib.rs' and 'src/some/mod.rs' do not end
   " with actual module names
-  if l:modules[-1] =~# '\v^(lib|mod)$'
+  if l:modules[-1] =~# '\v^(main|lib|mod)$'
     let l:modules = l:modules[:-2]
   endif
 

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -16,6 +16,10 @@ describe "Cargo"
     TestFile
     Expect g:test#last_command == 'cargo test '''''
 
+    view src/main.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test '''''
+
     view src/somemod.rs
     TestFile
     Expect g:test#last_command == 'cargo test ''somemod::'''

--- a/spec/fixtures/cargo/crate/src/main.rs
+++ b/spec/fixtures/cargo/crate/src/main.rs
@@ -1,0 +1,7 @@
+fn main() {}
+
+mod tests {
+    #[test]
+    fn first_test () {
+    }
+}


### PR DESCRIPTION
Before, if you ran tests in `main.rs`, it would invoke `cargo test main::` and not find any tests, but I don't think typically you will actually have a `main` module in `main.rs`.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly (n/a)
- [x] Update the Vim documentation in `doc/test.txt` (n/a)
