### PR TITLE
Make Python3 the default Python executable

### DIFF
--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -7,7 +7,7 @@ function! test#python#pyunit#test_file(file) abort
     if exists('g:test#python#runner')
       return g:test#python#runner ==# 'pyunit'
     else
-      return executable('python')
+      return executable('python3')
     endif
   endif
 endfunction

--- a/spec/pyunit_spec.vim
+++ b/spec/pyunit_spec.vim
@@ -16,22 +16,22 @@ describe "PyUnitTest"
     view +2 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestNumbers.test_numbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestNumbers.test_numbers'
 
     view +5 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestSubclass'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestSubclass'
 
     view +1 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestNumbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestNumbers'
 
     view +1 module/test_method.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_method.test_numbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_method.test_numbers'
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -39,21 +39,21 @@ describe "PyUnitTest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_method'
+    Expect g:test#last_command == 'python3 -m unittest module.test_method'
   end
 
   it "runs file tests"
     view module/test_class.py
     TestFile
 
-    Expect g:test#last_command == 'python -m unittest module.test_class'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class'
   end
 
   it "runs test suites"
     view test_class.py
     TestSuite
 
-    Expect g:test#last_command == 'python -m unittest'
+    Expect g:test#last_command == 'python3 -m unittest'
   end
 
 end


### PR DESCRIPTION
Time to move on and make Python3 at least be the default. Python 2 is no longer supported by the Python Software Foundation.
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner (n/a)
- [x] Update the README accordingly (n/a)
- [x] Update the Vim documentation in `doc/test.txt` (n/a)
