### PR TITLE
Avoid uncaught exception in test#base#build_args()

### DIFF
--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -34,7 +34,11 @@ function! test#base#build_args(runner, args, strategy)
   let no_color = has('gui_running') && a:strategy ==# 'basic'
 
   try
-    return test#{a:runner}#build_args(a:args, !no_color)
+    " Before Vim 8.0.1423 exceptions thrown from return statement
+    " cannot be caught.
+    " https://github.com/vim/vim/pull/2483
+    let args = test#{a:runner}#build_args(a:args, !no_color)
+    return args
   catch /^Vim\%((\a\+)\)\=:E118/ " too many arguments
     return test#{a:runner}#build_args(a:args)
   endtry

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -30,7 +30,7 @@ function! test#base#executable(runner) abort
   endif
 endfunction
 
-function! test#base#build_args(runner, args, strategy)
+function! test#base#build_args(runner, args, strategy) abort
   let no_color = has('gui_running') && a:strategy ==# 'basic'
 
   try

--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -39,7 +39,7 @@ function! test#base#build_args(runner, args, strategy) abort
     " https://github.com/vim/vim/pull/2483
     let args = test#{a:runner}#build_args(a:args, !no_color)
     return args
-  catch /^Vim\%((\a\+)\)\=:E118/ " too many arguments
+  catch /^Vim\%((\a\+)\)\=:E118:/ " too many arguments
     return test#{a:runner}#build_args(a:args)
   endtry
 endfunction


### PR DESCRIPTION
Test runners that provide build_args() taking one argument cannot be used in Vim before 8.0.1423 (and Neovim, #505).

This change adds workaround for Vim (and Neovim) versions that fail to caught an exception thrown from return statement (see vim/vim#2483).