### PR TITLE
Minitest: don't pick up RSpec files by mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ certain testing framework. You can override that pattern by overriding the
 `file_pattern` variable:
 
 ```vim
-let test#ruby#minitest#file_pattern = '_spec\.rb' " the default is '(((^|/)test_.+)|_test)\.rb'
+let test#ruby#minitest#file_pattern = '_spec\.rb' " the default is '\v(((^|/)test_.+)|_test)(spec)@<!\.rb$'
 ```
 
 ### Filename modifier

--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#ruby#minitest#file_pattern')
-  let g:test#ruby#minitest#file_pattern = '\v(((^|/)test_.+)|_test)\.rb$'
+  let g:test#ruby#minitest#file_pattern = '\v(((^|/)test_.+)|_test)(spec)@<!\.rb$'
 endif
 
 function! test#ruby#minitest#test_file(file) abort

--- a/spec/fixtures/minitest/test_spec.rb
+++ b/spec/fixtures/minitest/test_spec.rb
@@ -1,0 +1,9 @@
+# this is an RSpec file that ought not to get picked up by the
+# Minitest regex pattern
+RSpec.describe Test do
+  context 'when RSpec content is involved' do
+    it 'should not involve Minitest' do
+      1 + 1
+    end
+  end
+end

--- a/spec/minitest_spec.vim
+++ b/spec/minitest_spec.vim
@@ -178,4 +178,11 @@ describe "Minitest"
     Expect g:test#last_command == 'rake test TEST="test/**/{test_*,*_test}.rb" TESTOPTS="--seed=''1234''"'
   end
 
+  it "does not pick up RSpec files that start with 'test'"
+    view test_spec.rb
+    TestFile
+
+    Expect g:test#last_command == 'rspec test_spec.rb'
+  end
+
 end


### PR DESCRIPTION
I'm using (and loving, thank you!) vim-test in an RSpec based Ruby project. Everything was working great until I started trying to test a `Test` class. Because my class name is `Test`, the corresponding RSpec file name is `test_spec.rb`. When I attempt to run the RSpec tests inside this file, vim-test attempts to run Minitest instead of RSpec. This is understandable, as usually Minitest files have `test` in the name whereas RSpec files have `spec` in the name, but in this case my valid RSpec file has both `test` and `spec`.

This PR updates the Minitest file pattern regex to ignore a file starting with 'test' if it also ends with 'spec.rb'. I've added a new test fixture and unit test and the existing unit tests still pass.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] (N/A) Update the Vim documentation in `doc/test.txt`
