### PR TITLE
Update floaterm strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -94,7 +94,7 @@ function! test#strategy#neoterm(cmd) abort
 endfunction
 
 function! test#strategy#floaterm(cmd) abort
-  execute 'FloatermNew '.a:cmd
+  execute 'FloatermNew --autoclose=0 '.a:cmd
 endfunction
 
 function! test#strategy#vtr(cmd) abort


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

----

Right now, floating terminal window will be closed as soon as tests finished if the floaterm's global option `g:floaterm_autoclose` is `1` or `2`. This is not good design since user should be able to see the testing result.

Hence, the PR aims to keep the window opened until user move the cursor.

cc @codeinabox 