### PR TITLE
Add g:test#echo_command configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ if has('nvim')
 endif
 ```
 
+By default vim-test will echo the test command before running it. You can
+disable this behavior with:
+
+```vim
+let g:test#echo_command = 0
+```
+
 ### Kitty strategy setup
 
 Before you can run tests in a kitty terminal window using the kitty strategy,

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -201,15 +201,20 @@ function! s:execute_script(name, cmd) abort
 endfunction
 
 function! s:pretty_command(cmd) abort
-  let clear = !s:Windows() ? 'clear' : 'cls'
-  let echo  = !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd)
+  let cmds = []
   let separator = !s:Windows() ? '; ' : ' & '
 
   if !get(g:, 'test#preserve_screen')
-    return join([l:clear, l:echo, a:cmd], l:separator)
-  else
-    return join([l:echo, a:cmd], l:separator)
+    call add(l:cmds, !s:Windows() ? 'clear' : 'cls')
   endif
+
+  if get(g:, 'test#echo_command', 1)
+    call add(l:cmds, !s:Windows() ? 'echo -e '.shellescape(a:cmd) : 'Echo '.shellescape(a:cmd))
+  endif
+
+  call add(l:cmds, a:cmd)
+
+  return join(l:cmds, l:separator)
 endfunction
 
 function! s:command(cmd) abort

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -546,6 +546,11 @@ If you want to disable clearing the screen for strategies, you can do
 >
   let g:test#preserve_screen = 1
 <
+By default, vim-test will echo the test command before running it. You can
+disable this behavior with
+>
+  let g:test#echo_command = 0
+<
 You may find yourself specifying certain options for your test runners in
 certain situations. You can configure your preferred options with
 >


### PR DESCRIPTION
This allows users to disable echoing the test command before running it.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
  - didn't do this because it doesn't affect any one runner. i also didn't see comparable tests for `g:test#preserve_screen`.
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
