### PR TITLE
Made maven java dir optional

### DIFF
--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -50,7 +50,7 @@ function! s:get_java_package(filepath)
   let abspath = substitute(a:filepath, '\\', '/', 'g')
 
   " strip path-to-project and maven-boilerplate dir-structure
-  let relpath = substitute(abspath, '^.*src/\(main\|test\)/\(java/\)?', "", "g")
+  let relpath = substitute(abspath, '^.*src/\(main\|test\)/\(java/\)\?', "", "g")
   let package_path = substitute(relpath, '\/[^/]\+$', "", "g")
   let java_package = substitute(package_path, '/', '.', 'g')
   return java_package

--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -50,7 +50,7 @@ function! s:get_java_package(filepath)
   let abspath = substitute(a:filepath, '\\', '/', 'g')
 
   " strip path-to-project and maven-boilerplate dir-structure
-  let relpath = substitute(abspath, '^.*src/\(main\|test\)/java/', "", "g")
+  let relpath = substitute(abspath, '^.*src/\(main\|test\)/\(java/\)?', "", "g")
   let package_path = substitute(relpath, '\/[^/]\+$', "", "g")
   let java_package = substitute(package_path, '/', '.', 'g')
   return java_package


### PR DESCRIPTION
Very minor (and probably niche) change. Made the maven directory src/main/java optional such that src/main will also match.
Why would I want this? I hate deep directory structures with no meaning, and since my project is excursively java it was redundant. This tiny regex change shouldn't effect anyone with a normal maven structure, and will make my weird structure compatible with the plugin. 
