### PR TITLE
Replace rails check with railties check

### DIFF
--- a/autoload/test/ruby/rails.vim
+++ b/autoload/test/ruby/rails.vim
@@ -45,7 +45,7 @@ endfunction
 function! s:rails_version() abort
   if filereadable('Gemfile.lock')
     for line in readfile('Gemfile.lock')
-      let version_string = matchstr(line, '\v^ *rails \(\zs\d+\.\d+\..+\ze\)')
+      let version_string = matchstr(line, '\v^ *railties \(\zs\d+\.\d+\..+\ze\)')
       if version_string
         break
       endif

--- a/spec/fixtures/rails-engine/Gemfile.lock
+++ b/spec/fixtures/rails-engine/Gemfile.lock
@@ -1,1 +1,2 @@
-rails (5.2.3)
+railties (>= 4.2.0)
+railties (5.2.3)

--- a/spec/fixtures/rails/Gemfile.lock
+++ b/spec/fixtures/rails/Gemfile.lock
@@ -1,1 +1,2 @@
-rails (5.2.3)
+railties (>= 4.2.0)
+railties (5.2.3)


### PR DESCRIPTION
Some applications don't use the `rails` gem explicitly and instead
depend on its components separately, such as `activerecord`,
`activesupport`, etc. When this is how an application requires rails, it
causes the test command to use `bin/rake` instead of `bin/rails` causing
tests not to run.

This resolves the issue by checking the `railties` version which should
always be present, even when `rails` isn't.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
