### PR TITLE
Update the vimux strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -103,10 +103,8 @@ endfunction
 
 function! test#strategy#vimux(cmd) abort
   if exists('g:test#preserve_screen') && !g:test#preserve_screen
-    if exists('g:VimuxRunnerIndex') && _VimuxHasRunner(g:VimuxRunnerIndex) != -1
-      call VimuxRunCommand(!s:Windows() ? 'clear' : 'cls')
-      call VimuxClearRunnerHistory()
-    endif
+    call VimuxClearTerminalScreen()
+    call VimuxClearRunnerHistory()
     call VimuxRunCommand(s:command(a:cmd))
   else
     call VimuxRunCommand(s:pretty_command(a:cmd))


### PR DESCRIPTION
The `_VimuxHasRunner` has been removed from the vimux codebase.
For this reason, running tests multiple times will result in the
following error:

    Error detected while processing function test#run[26]..test#execute[22]..test#shell[19]..test#strategy#vimux:
    line    2:
    E117: Unknown function: _VimuxHasRunner
    E15: Invalid expression: exists('g:VimuxRunnerIndex') && _VimuxHasRunner(g:VimuxRunnerIndex) != -1
    Error detected while processing function test#run[26]..test#execute[22]..test#shell[19]..test#strategy#vimux:
    line    2:
    E117: Unknown function: _VimuxHasRunner
    E15: Invalid expression: exists('g:VimuxRunnerIndex') && _VimuxHasRunner(g:VimuxRunnerIndex) != -1

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] ~Update the README accordingly~
- [ ] ~Update the Vim documentation in `doc/test.txt`~
