### PR TITLE
Allow starting neovim term in normal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ if has('nvim')
 endif
 ```
 
+If you prefer, you can instead have the terminal open in normal mode, so it does
+not close on key press.
+
+```vim
+let g:test#neovim#start_normal = 1 # If using neovim strategy
+let g:test#basic#start_normal = 1 # If using basic strategy
+```
+
 By default vim-test will echo the test command before running it. You can
 disable this behavior with:
 

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -6,7 +6,9 @@ function! test#strategy#basic(cmd) abort
   if has('nvim')
     -tabnew
     call termopen(a:cmd)
-    startinsert
+    if !get(g:, 'test:basic:start_normal', 0)
+      startinsert
+    endif
   else
     if s:restorescreen()
       execute '!'.s:pretty_command(a:cmd)
@@ -76,7 +78,9 @@ function! test#strategy#neovim(cmd) abort
   execute term_position . ' new'
   call termopen(a:cmd)
   au BufDelete <buffer> wincmd p " switch back to last window
-  startinsert
+  if !get(g:, 'test#neovim#start_normal', 0)
+    startinsert
+  endif
 endfunction
 
 function! test#strategy#vimterminal(cmd) abort

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -615,6 +615,14 @@ for neovim and
 <
 for vim
 
+By default, the `neovim` and `basic` (when using Neovim) strategies will open a
+terminal in insert mode, so that you can press any key to close the split. If
+you would prefer to open the terminal in normal mode:
+>
+  let test#neovim#start_normal = 1 # if using neovim strategy
+  let test#basic#start_normal = 1 # if using basic strategy
+<
+
 
 PROJECTIONIST INTEGRATION                       *test-projectionist*
 


### PR DESCRIPTION
Resolves #577 

- [x] ~Add fixtures and spec when implementing or updating a test runner~
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

Added new options `test#neovim#start_normal` and `test#basic#start_normal` which allow not switching to insert mode when opening a terminal in Neovim.