### PR TITLE
Add harpoon integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ let test#strategy = "dispatch"
 | **iTerm2.app**                  | `iterm`                                                     | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                                                                                                      |
 | **[Kitty]**                     | `kitty`                                                     | Sends test commands to Kitty terminal.                                                                                                                            |
 | **[Shtuff]**                    | `shtuff`                                                    | Sends test commands to remote terminal via [shtuff][Shtuff].                                                                                                      |
-| **[Harpoon]**                    | `harpoon`                                                    | Sends test commands to neovim terminal using a terminal managed by harpoon. By default commands are sent to terminal number 1, you can choose your terminal by setting `g:test#harpoon_term` with the terminal you want                                                                                                     |
+| **[Harpoon]**                    | `harpoon`                                                    | Sends test commands to neovim terminal using a terminal managed by [harpoon][Harpoon]. By default commands are sent to terminal number 1, you can choose your terminal by setting `g:test#harpoon_term` with the terminal you want                                                                                                     |
 
 You can also set up strategies per granularity:
 
@@ -671,3 +671,4 @@ Copyright © Janko Marohnić. Distributed under the same terms as Vim itself. Se
 [projectionist.vim]: https://github.com/tpope/vim-projectionist
 [Kitty]: https://github.com/kovidgoyal/kitty
 [Shtuff]: https://github.com/jfly/shtuff
+[Harpoon]: https://github.com/ThePrimeagen/harpoon

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ let test#strategy = "dispatch"
 | **iTerm2.app**                  | `iterm`                                                     | Sends test commands to iTerm2 >= 2.9 (useful in MacVim GUI).                                                                                                      |
 | **[Kitty]**                     | `kitty`                                                     | Sends test commands to Kitty terminal.                                                                                                                            |
 | **[Shtuff]**                    | `shtuff`                                                    | Sends test commands to remote terminal via [shtuff][Shtuff].                                                                                                      |
+| **[Harpoon]**                    | `harpoon`                                                    | Sends test commands to neovim terminal using a terminal managed by harpoon. By default commands are sent to terminal number 1, you can choose your terminal by setting `g:test#harpoon_term` with the terminal you want                                                                                                     |
 
 You can also set up strategies per granularity:
 

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -165,6 +165,17 @@ function! test#strategy#shtuff(cmd) abort
   call system("shtuff into " . shellescape(g:shtuff_receiver) . " " . shellescape("clear;" . a:cmd))
 endfunction
 
+function! test#strategy#harpoon(cmd) abort
+  let g:cmd = a:cmd . "\n"
+  if(exists("g:test#harpoon_term"))
+    lua require("harpoon.term").sendCommand(vim.g["test#harpoon_term"] ,vim.g.cmd)
+    lua require("harpoon.term").gotoTerminal(vim.g["test#harpoon_term"])
+  else
+    lua require("harpoon.term").sendCommand(1 ,vim.g.cmd)
+    lua require("harpoon.term").gotoTerminal(1)
+  endif
+endfunction
+
 function! s:execute_with_compiler(cmd, script) abort
   try
     let default_makeprg = &l:makeprg

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -473,6 +473,20 @@ settings. If you want to switch between them then change `test#strategy`.
 Note: that the base `asyncrun` strategy will be affected by your global asyncrun
 settings.
 
+Harpoon ~
+
+This strategy lets you run commands in a neovim terminal using harpoon terminals
+
+Before you can use this strategy you are going to need to have the harpoon plugin installed
+
+By default the commands are sent to the terminal 1, to send the command to another terminal you con set in you vimrc g:test#harpoon_term
+
+For example to send the commands to terminal number 2 you can set in your vimrc:
+
+>
+let g:test#harpoon_term = 2
+<
+
 QUICKFIX STRATEGIES                               *test-quickfix-strategies*
 
 If you want your test results to appear in the |quickfix| window, use one of the


### PR DESCRIPTION
Added a strategy to integrate vim-test with [harpoon](https://github.com/ThePrimeagen/harpoon) a plugin to access files and terminals with few keystrokes. I share what I did whit ThePrimeagen community and they told me I could go and make a PR

Basically i sent the commands through harpoon 
By default it sends them to terminal number 1 and I also added the posibility to set a specific terminal with a variable in the vimrc

It is my first time contributing to an open source project and i never programmed in vimscript so anything you want to comment is welcome

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
