### PR TITLE
Configure not to go to the terminal with harpoon

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -169,10 +169,14 @@ function! test#strategy#harpoon(cmd) abort
   let g:cmd = a:cmd . "\n"
   if(exists("g:test#harpoon_term"))
     lua require("harpoon.term").sendCommand(vim.g["test#harpoon_term"] ,vim.g.cmd)
-    lua require("harpoon.term").gotoTerminal(vim.g["test#harpoon_term"])
+    if !exists("g:test#harpoon_stay_here")
+      lua require("harpoon.term").gotoTerminal(vim.g["test#harpoon_term"])
+    endif
   else
     lua require("harpoon.term").sendCommand(1 ,vim.g.cmd)
-    lua require("harpoon.term").gotoTerminal(1)
+    if !exists("g:test#harpoon_stay_here")
+      lua require("harpoon.term").gotoTerminal(1)
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
I'm using it this way, it is practical with the terminal in a vsplit !

Then to set : 
`let g:test#harpoon_stay_here = 1`
to unset : 
`unlet g:test#harpoon_stay_here`

Maybe the next step is to automatically create the vplit/split. But it might over complexify for too few benefits, so I haven't added it.

NB : have fun renaming my terrible var's name ><

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
