### PR TITLE
Return to the same directory on failed run

### DIFF
--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -11,6 +11,7 @@ function! test#run(type, arguments) abort
   elseif exists('g:test#last_position')
     let position = g:test#last_position
   else
+    call s:after_run()
     call s:echo_failure('Not a test file') | return
   endif
 


### PR DESCRIPTION
With this change, if the failure "Not a test file" is encountered, `after_run` is ran before returning. `after_run` will run `cd -` which will resolve to the directory before the last `cd`. This achieves some symmetry if `g:test#project_root` is set(cd to the directory before tests are run => cd back).

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner 
(There seems to be no tests with `g:test#project_root`, so I'm not sure this is needed?)
- [ ] Update the README accordingly
(Feels like a bug to me, should this be documented really?)
- [ ] Update the Vim documentation in `doc/test.txt`
(Ditto)
