### PR TITLE
Add support for cucumber-js 7+

### DIFF
--- a/autoload/test/javascript/cucumberjs.vim
+++ b/autoload/test/javascript/cucumberjs.vim
@@ -8,6 +8,7 @@ function! test#javascript#cucumberjs#test_file(file) abort
           return g:test#javascript#runner ==# 'cucumber'
       else
         return test#javascript#has_package('cucumber')
+                    \|| test#javascript#has_package('@cucumber/cucumber')
       endif
   endif
 endfunction

--- a/spec/cucumberjs7+_spec.vim
+++ b/spec/cucumberjs7+_spec.vim
@@ -1,0 +1,58 @@
+source spec/support/helpers.vim
+
+describe "CucumberJS - 7+"
+
+  before
+    cd spec/fixtures/cucumberjs7+
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs selected scenario tests"
+    view +6 features/normal.feature
+    TestNearest
+
+    Expect g:test#last_command == 'cucumber-js features/normal.feature:6'
+  end
+
+  it "runs nearest scenario tests"
+    view +7 features/normal.feature
+    TestNearest
+
+    Expect g:test#last_command == 'cucumber-js features/normal.feature:6'
+  end
+
+  it "runs file tests"
+    view features/normal.feature
+    TestFile
+
+    Expect g:test#last_command == 'cucumber-js features/normal.feature'
+  end
+
+  it "runs test suites"
+    view features/normal.feature
+    TestSuite
+
+    Expect g:test#last_command == 'cucumber-js'
+  end
+
+  it "uses locally installed cucumber-js"
+    try
+      !mkdir -p node_modules/.bin
+      !touch node_modules/.bin/cucumber-js
+
+      view features/normal.feature
+      TestSuite
+
+      Expect g:test#last_command == 'node_modules/.bin/cucumber-js'
+    finally
+      " play it safe with the removal of files (i.e. no rm -rf)
+      !rm node_modules/.bin/cucumber-js
+      !rmdir node_modules/.bin
+      !rmdir node_modules
+    endtry
+  end
+end

--- a/spec/fixtures/cucumberjs7+/features/normal.feature
+++ b/spec/fixtures/cucumberjs7+/features/normal.feature
@@ -1,0 +1,9 @@
+Feature: Numbers
+  Scenario: Addition
+    When I add 1 and 1
+    Then I should get 2
+
+  Scenario: Subtraction
+    When I subtract 1 and 1
+    Then I should get 0
+

--- a/spec/fixtures/cucumberjs7+/features/step_definitions/steps.js
+++ b/spec/fixtures/cucumberjs7+/features/step_definitions/steps.js
@@ -1,0 +1,1 @@
+// some step definitions

--- a/spec/fixtures/cucumberjs7+/package.json
+++ b/spec/fixtures/cucumberjs7+/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test",
+  "version": "1.0.0",
+  "description": "",
+  "devDependencies": {
+    "@cucumber/cucumber": "^7.0.0"
+  }
+}


### PR DESCRIPTION
The cucumber-js module changed from `cucumber` to `@cucumber/cucumber`
in version 7+.

Make sure these boxes are checked before submitting your pull request:

- [X ] Add fixtures and spec when implementing or updating a test runner
