### PR TITLE
Enable backtick surrounded test names in Kotlin

### DIFF
--- a/autoload/test/kotlin.vim
+++ b/autoload/test/kotlin.vim
@@ -1,7 +1,7 @@
 let s:line_start = '\v^\s*'
 let s:optional_test_decorator = '%(\zs\@Test\s+\ze)?'
 let s:optional_public_modifier = '%(\zspublic\s+\ze)?'
-let s:function_def = 'fun\s+((\w)+|`.+`)'
+let s:function_def = 'fun\s+(\w+|`.+`)'
 let s:class_def = 'class\s+(\w+)'
 
 let test#kotlin#patterns = {

--- a/autoload/test/kotlin.vim
+++ b/autoload/test/kotlin.vim
@@ -1,7 +1,7 @@
 let s:line_start = '\v^\s*'
 let s:optional_test_decorator = '%(\zs\@Test\s+\ze)?'
 let s:optional_public_modifier = '%(\zspublic\s+\ze)?'
-let s:function_def = 'fun\s+(\w+)'
+let s:function_def = 'fun\s+((\w)+|`.+`)'
 let s:class_def = 'class\s+(\w+)'
 
 let test#kotlin#patterns = {

--- a/autoload/test/kotlin/gradletest.vim
+++ b/autoload/test/kotlin/gradletest.vim
@@ -10,7 +10,7 @@ function! test#kotlin#gradletest#build_position(type, position) abort
   let filename = fnamemodify(a:position['file'], ':t:r')
   let modulename = s:get_module(a:position['file'])
   if a:type ==# 'nearest'
-    let name = s:nearest_test(a:position)
+    let name = substitute(s:nearest_test(a:position), '`', '"', "g")
     if !empty(name)
       return ['--tests ' . name . modulename]
     else

--- a/spec/fixtures/gradle/kotlin/gradle_plain/CalculationTest.kt
+++ b/spec/fixtures/gradle/kotlin/gradle_plain/CalculationTest.kt
@@ -23,6 +23,12 @@ class CalculationTest {
     }
 
     @Test
+    fun `tests calculating a sum of 3 + 5`() {
+        val sum = Calculation.add(3, 5)
+        assertEquals(sum, 8)
+    }
+
+    @Test
     fun testFailedSub() {
         val sum = Calculation.sub(5, 3)
         assertEquals(sum, 3)

--- a/spec/fixtures/gradle/kotlin/gradle_plain_kotlin_dsl/CalculationTest.kt
+++ b/spec/fixtures/gradle/kotlin/gradle_plain_kotlin_dsl/CalculationTest.kt
@@ -23,6 +23,12 @@ class CalculationTest {
     }
 
     @Test
+    fun `tests calculating a sum of 3 + 5`() {
+        val sum = Calculation.add(3, 5)
+        assertEquals(sum, 8)
+    }
+
+    @Test
     fun testFailedSub() {
         val sum = Calculation.sub(5, 3)
         assertEquals(sum, 3)

--- a/spec/kotlin_gradletest_spec.vim
+++ b/spec/kotlin_gradletest_spec.vim
@@ -52,6 +52,13 @@ describe "Gradle plain module"
     Expect g:test#last_command == "./gradlew test --tests CalculationTest.testFailedSub"
   end
 
+  it "runs nearest tests which has a backtick surrounded name"
+    view +27  CalculationTest.kt
+    TestNearest
+
+    Expect g:test#last_command == "./gradlew test --tests CalculationTest.\"tests calculating a sum of 3 + 5\""
+  end
+
   it "runs a suite"
     view  CalculationTest.kt
     TestSuite

--- a/spec/kotlin_gradletest_spec_koltin_dsl.vim
+++ b/spec/kotlin_gradletest_spec_koltin_dsl.vim
@@ -52,6 +52,13 @@ describe "Gradle plain module"
     Expect g:test#last_command == "./gradlew test --tests CalculationTest.testFailedSub"
   end
 
+  it "runs nearest tests which has a backtick surrounded name"
+    view +27  CalculationTest.kt
+    TestNearest
+
+    Expect g:test#last_command == "./gradlew test --tests CalculationTest.\"tests calculating a sum of 3 + 5\""
+  end
+
   it "runs a suite"
     view  CalculationTest.kt
     TestSuite


### PR DESCRIPTION
In Kotlin, test function names can be surrounded by backticks. https://todd.ginsberg.com/post/kotlin-function-names/

This PR would update the regex (to match any character between backticks) and replace the backticks in the gradle command by `"`.

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`

README and docs updates not needed.