### PR TITLE
Pick long name Flutter test with TestNearest command

### DIFF
--- a/autoload/test/dart/fluttertest.vim
+++ b/autoload/test/dart/fluttertest.vim
@@ -1,5 +1,5 @@
 let g:test#dart#fluttertest#patterns = {
-  \ 'test':      ['\v^\s*%(test|testWidgets)\(%(''|")(.*)%(''|"),'],
+  \ 'test':      ['\v^\s*%(test|testWidgets)\(%(''|")(.*)%(''|"),', '\v^\s*%(''|")(.{50,})%(''|"),'],
   \ 'namespace': ['\v^\s*group\(%(''|")(.*)%(''|"),'],
 \}
 

--- a/spec/fixtures/fluttertest/widgets_test.dart
+++ b/spec/fixtures/fluttertest/widgets_test.dart
@@ -20,5 +20,34 @@ void main() {
 
       expect(descriptionFinder, findsNothing);
     });
+
+    testWidgets(
+      'has very very very very very very very very very very very long description',
+      (WidgetTester tester) async {
+      await tester.pumpWidget(MyWidget(title: 'T', message: 'M'));
+
+      final titleFinder = find.text('T');
+      final messageFinder = find.text('M');
+
+      expect(titleFinder, findsOneWidget);
+      expect(messageFinder, findsOneWidget);
+    });
+
+    testWidgets(
+        'test with string array and very very very very very very very very very very very long description',
+        (tester) async {
+      final a = [
+        'a',
+        'b',
+        'c',
+      ];
+
+      await tester.pumpWidget(
+        const Center(),
+      );
+      await tester.pump();
+
+      expect(find.text('Jan 24'), findsOneWidget);
+    });
   });
 }

--- a/spec/fluttertest_spec.vim
+++ b/spec/fluttertest_spec.vim
@@ -27,6 +27,16 @@ describe "FlutterTest"
     TestNearest
 
     Expect g:test#last_command == 'flutter test --plain-name "MyWidget doesn''t have description" widgets_test.dart'
+
+    view +30 widgets_test.dart
+    TestNearest
+
+    Expect g:test#last_command == 'flutter test --plain-name "MyWidget has very very very very very very very very very very very long description" widgets_test.dart'
+
+    view +50 widgets_test.dart
+    TestNearest
+
+    Expect g:test#last_command == 'flutter test --plain-name "MyWidget test with string array and very very very very very very very very very very very long description" widgets_test.dart'
   end
 
   it "runs test suites"


### PR DESCRIPTION
When the test description is very long dart formatter moves the description to a separate line. Additional regex help match this line, if it is long enough (I arbitrary chosen more than 50 chars length).

It fixes #602

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
