### PR TITLE
fix test function pattern for Go

### DIFF
--- a/autoload/test/go.vim
+++ b/autoload/test/go.vim
@@ -1,5 +1,5 @@
 let test#go#patterns = {
-  \ 'test':      ['\v^\s*func (\w+)'],
+  \ 'test':      ['\v^\s*func ((Test|Example).*)\('],
   \ 'namespace': [],
 \}
 function! test#go#test_file(runner, file_pattern, file) abort

--- a/spec/delve_spec.vim
+++ b/spec/delve_spec.vim
@@ -17,6 +17,16 @@ describe "Delve"
     TestNearest
 
     Expect g:test#last_command == 'dlv test ./. -- -test.run ''TestNumbers$'''
+
+    view +9 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./. -- -test.run ''Testテスト$'''
+
+    view +13 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./. -- -test.run ''ExampleSomething$'''
   end
 
   it "runs nearest tests in subdirectory"
@@ -24,6 +34,16 @@ describe "Delve"
     TestNearest
 
     Expect g:test#last_command == 'dlv test ./mypackage -- -test.run ''TestNumbers$'''
+
+    view +9 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./mypackage -- -test.run ''Testテスト$'''
+
+    view +13 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'dlv test ./mypackage -- -test.run ''ExampleSomething$'''
   end
 
   it "runs file test if nearest test couldn't be found"

--- a/spec/fixtures/delve/mypackage/normal_test.go
+++ b/spec/fixtures/delve/mypackage/normal_test.go
@@ -5,3 +5,14 @@ import "testing"
 func TestNumbers(*testing.T) {
 	// assertions
 }
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/spec/fixtures/delve/normal_test.go
+++ b/spec/fixtures/delve/normal_test.go
@@ -3,5 +3,16 @@ package mypackage
 import "testing"
 
 func TestNumbers(*testing.T) {
-    // assertions
+	// assertions
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
 }

--- a/spec/fixtures/gotest/mypackage/normal_test.go
+++ b/spec/fixtures/gotest/mypackage/normal_test.go
@@ -5,3 +5,14 @@ import "testing"
 func TestNumbers(*testing.T) {
 	// assertions
 }
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/spec/fixtures/gotest/normal_test.go
+++ b/spec/fixtures/gotest/normal_test.go
@@ -3,5 +3,16 @@ package mypackage
 import "testing"
 
 func TestNumbers(*testing.T) {
-    // assertions
+	// assertions
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
 }

--- a/spec/fixtures/richgo/mypackage/normal_test.go
+++ b/spec/fixtures/richgo/mypackage/normal_test.go
@@ -5,3 +5,14 @@ import "testing"
 func TestNumbers(*testing.T) {
 	// assertions
 }
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/spec/fixtures/richgo/normal_test.go
+++ b/spec/fixtures/richgo/normal_test.go
@@ -5,3 +5,14 @@ import "testing"
 func TestNumbers(*testing.T) {
 	// assertions
 }
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -16,6 +16,16 @@ describe "GoTest"
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./.'
+
+    view +9 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''Testテスト$'' ./.'
+
+    view +13 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''ExampleSomething$'' ./.'
   end
 
   it "runs nearest tests in subdirectory"
@@ -23,6 +33,16 @@ describe "GoTest"
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./mypackage'
+
+    view +9 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''Testテスト$'' ./mypackage'
+
+    view +13 mypackage/normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''ExampleSomething$'' ./mypackage'
   end
 
   it "runs file test if nearest test couldn't be found"

--- a/spec/richgo_spec.vim
+++ b/spec/richgo_spec.vim
@@ -15,12 +15,28 @@ describe "RichGo"
     view +5 normal_test.go
     TestNearest
     Expect g:test#last_command == "richgo test -run 'TestNumbers$' ./."
+
+    view +9 normal_test.go
+    TestNearest
+    Expect g:test#last_command == "richgo test -run 'Testテスト$' ./."
+
+    view +13 normal_test.go
+    TestNearest
+    Expect g:test#last_command == "richgo test -run 'ExampleSomething$' ./."
   end
 
   it "runs nearest tests in subdirectory"
     view +5 mypackage/normal_test.go
     TestNearest
     Expect g:test#last_command == "richgo test -run 'TestNumbers$' ./mypackage"
+
+    view +9 mypackage/normal_test.go
+    TestNearest
+    Expect g:test#last_command == "richgo test -run 'Testテスト$' ./mypackage"
+
+    view +13 mypackage/normal_test.go
+    TestNearest
+    Expect g:test#last_command == "richgo test -run 'ExampleSomething$' ./mypackage"
   end
 
   it "runs file test if nearest test couldn't be found"


### PR DESCRIPTION
In Go, test function name rule is to begin with `Test`.
Actually, `Testテスト` is testable.

```
> go test -v . --run Testテスト
=== RUN   Testテスト
--- PASS: Testテスト (0.00s)
PASS
ok      github.com/lunarxlark/test     0.243s
```

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
