### PR TITLE
Allow configuring stack test command

### DIFF
--- a/autoload/test/haskell/stacktest.vim
+++ b/autoload/test/haskell/stacktest.vim
@@ -2,6 +2,10 @@ if !exists('g:test#haskell#stacktest#file_pattern')
   let g:test#haskell#stacktest#file_pattern = '\v^(.*spec.*)\c\.hs$'
 endif
 
+if !exists('g:test#haskell#stacktest#test_command')
+  let g:test#haskell#stacktest#test_command = 'test'
+endif
+
 " Returns true if the given file belongs to your test runner
 function! test#haskell#stacktest#test_file(file) abort
   return test#haskell#test_file('stacktest', g:test#haskell#stacktest#file_pattern, a:file)
@@ -15,15 +19,15 @@ function! test#haskell#stacktest#build_position(type, position) abort
     let name = s:nearest_test(a:position)
     let s:module_name = substitute(filename, "Spec", "", "")
     if !empty(name)
-      return ["test " . "--test-arguments '-m \"" . name . "\"'"]
+      return [g:test#haskell#stacktest#test_command, "--test-arguments '-m \"" . name . "\"'"]
     else
-      return ["test " . "--test-arguments '-m \"" . s:module_name . "\"'"]
+      return [g:test#haskell#stacktest#test_command, "--test-arguments '-m \"" . s:module_name . "\"'"]
     endif
   elseif a:type ==# 'file'
     let s:module_name = substitute(filename, "Spec", "", "")
-    return ["test " . "--test-arguments '-m \"" . s:module_name . "\"'"]
+    return [g:test#haskell#stacktest#test_command, "--test-arguments '-m \"" . s:module_name . "\"'"]
   else
-    return ['"test"']
+    return [g:test#haskell#stacktest#test_command]
   endif
 endfunction
 

--- a/spec/stacktest_spec.vim
+++ b/spec/stacktest_spec.vim
@@ -29,7 +29,16 @@ describe "STACK"
     view FixtureSpec.hs
     TestSuite
 
-    Expect g:test#last_command == 'stack "test"'
+    Expect g:test#last_command == 'stack test'
+  end
+
+  it "allows overriding the test command"
+    let g:test#haskell#stacktest#test_command = 'test .'
+
+    view FixtureSpec.hs
+    TestSuite
+
+    Expect g:test#last_command == 'stack test .'
   end
 
 end


### PR DESCRIPTION
This PR allows overriding the test command for Haskell's `stack`. Specifically, it allows you to use `test .` as the default command, which works better in multi-package stack projects.