### PR TITLE
fix: dotnettest search

### DIFF
--- a/autoload/test/csharp.vim
+++ b/autoload/test/csharp.vim
@@ -19,7 +19,7 @@ function! test#csharp#get_project_path(file) abort
   endwhile
 
   if len(l:project_files) == 0
-    throw 'Unable to find .csproj file, a .csproj file is required to make use of the `dotnet test` command.'
+    return []
   endif
 
   return l:project_files[0]

--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -15,7 +15,7 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   let file = a:position['file']
   let filename = fnamemodify(file, ':t:r')
   let project_path = test#csharp#get_project_path(file)
-  let name = test#base#nearest_test(a:position, g:test#csharp#patterns)
+  let name = test#base#nearest_test(a:position, g:test#csharp#patterns, { 'namespaces_with_same_indent': 1 })
   let namespace = join(name['namespace'], '.')
   let test_name = join(name['test'], '.')
   let nearest_test = join([namespace, test_name], '.')

--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -21,7 +21,7 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   let nearest_test = join([namespace, test_name], '.')
 
   if a:type ==# 'nearest'
-    if !empty(nearest_test)
+    if !empty(test_name)
       return [project_path, '--filter', 'FullyQualifiedName=' . nearest_test]
     else
       if !empty(namespace)
@@ -31,7 +31,7 @@ function! test#csharp#dotnettest#build_position(type, position) abort
       endif
     endif
   elseif a:type ==# 'file'
-    return [project_path,  '--filter', 'FullyQualifiedName~' . namespace]
+    throw 'file tests is not supported for dotnettest'
   elseif a:type ==# 'suite'
     if !empty(project_path)
       return [project_path]

--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -15,18 +15,29 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   let file = a:position['file']
   let filename = fnamemodify(file, ':t:r')
   let project_path = test#csharp#get_project_path(file)
+  let name = test#base#nearest_test(a:position, g:test#csharp#patterns)
+  let namespace = join(name['namespace'], '.')
+  let test_name = join(name['test'], '.')
+  let nearest_test = join([namespace, test_name], '.')
 
   if a:type ==# 'nearest'
-    let name = s:nearest_test(a:position)
-    if !empty(name)
-      return [project_path, '--filter', 'FullyQualifiedName~' . name]
+    if !empty(nearest_test)
+      return [project_path, '--filter', 'FullyQualifiedName=' . nearest_test]
     else
-      return [project_path, '--filter', 'FullyQualifiedName~' . filename]
+      if !empty(namespace)
+        return [project_path, '--filter', 'FullyQualifiedName~' . namespace]
+      else
+        return [project_path]
+      endif
     endif
   elseif a:type ==# 'file'
-    return [project_path,  '--filter', 'FullyQualifiedName~' . filename]
-  else
-    return [project_path]
+    return [project_path,  '--filter', 'FullyQualifiedName~' . namespace]
+  elseif a:type ==# 'suite'
+    if !empty(project_path)
+      return [project_path]
+    else
+      return []
+    endif
   endif
 endfunction
 
@@ -37,9 +48,4 @@ endfunction
 
 function! test#csharp#dotnettest#executable() abort
   return 'dotnet test'
-endfunction
-
-function! s:nearest_test(position) abort
-  let name = test#base#nearest_test(a:position, g:test#csharp#patterns)
-  return join(name['namespace'] + name['test'], '.')
 endfunction

--- a/autoload/test/csharp/dotnettest.vim
+++ b/autoload/test/csharp/dotnettest.vim
@@ -19,12 +19,12 @@ function! test#csharp#dotnettest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      return [project_path, '--filter', 'FullyQualifiedName=' . name]
+      return [project_path, '--filter', 'FullyQualifiedName~' . name]
     else
-      return [project_path, '--filter', 'FullyQualifiedName=' . filename]
+      return [project_path, '--filter', 'FullyQualifiedName~' . filename]
     endif
   elseif a:type ==# 'file'
-    return [project_path,  '--filter', 'FullyQualifiedName=' . filename]
+    return [project_path,  '--filter', 'FullyQualifiedName~' . filename]
   else
     return [project_path]
   endif

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -15,6 +15,14 @@ describe "DotnetTest"
     cd -
   end
 
+  it "runs nearest tests for file namespace"
+    view +6 FileNamespaceTests.cs
+    TestNearest
+
+    let actual = s:remove_path(g:test#last_command)
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests.TestAsyncWithTaskReturn'
+  end
+
   it "runs nearest tests"
     view +3 Tests.cs
     TestNearest
@@ -39,7 +47,6 @@ describe "DotnetTest"
 
     let actual = s:remove_path(g:test#last_command)
     Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests.TestAsyncWithTaskReturn'
-
   end
 
   it "runs file test if nearest test couldn't be found"

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -43,7 +43,7 @@ describe "DotnetTest"
   end
 
   it "runs file test if nearest test couldn't be found"
-    view +1 Tests.cs
+    view +2 Tests.cs
     normal O
     TestNearest
 

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -48,15 +48,7 @@ describe "DotnetTest"
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace.Tests'
-  end
-
-  it "runs file tests"
-    view Tests.cs
-    TestFile
-
-    let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace.Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace'
   end
 
   it "runs test suites"

--- a/spec/dotnet_spec.vim
+++ b/spec/dotnet_spec.vim
@@ -20,7 +20,7 @@ describe "DotnetTest"
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Namespace.Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace.Tests'
 
     view +8 Tests.cs
     TestNearest
@@ -48,7 +48,7 @@ describe "DotnetTest"
     TestNearest
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace.Tests'
   end
 
   it "runs file tests"
@@ -56,7 +56,7 @@ describe "DotnetTest"
     TestFile
 
     let actual = s:remove_path(g:test#last_command)
-    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName=Tests'
+    Expect actual == 'dotnet test Tests.csproj --filter FullyQualifiedName~Namespace.Tests'
   end
 
   it "runs test suites"

--- a/spec/fixtures/dotnet/FileNamespaceTests.cs
+++ b/spec/fixtures/dotnet/FileNamespaceTests.cs
@@ -1,0 +1,10 @@
+namespace Namespace;
+
+public class Tests
+{
+    [Fact]
+    public async Task TestAsyncWithTaskReturn()
+    {
+        Assert.Equal(true, false);
+    }
+}


### PR DESCRIPTION
Rework dotnettest. Now it uses right filters and support file namespaces.
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
