### PR TITLE
Update to Ginkgo v2

### DIFF
--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -15,13 +15,13 @@ function! test#go#ginkgo#build_position(type, position) abort
   if a:type ==# 'suite'
     return [path]
   else
-    let fileargs = ['--regexScansFilePath=true '.'--focus='.a:position['file'], path]
+    let fileargs = ['--focus-file='.a:position['file'], path]
     if a:type ==# 'file'
       return fileargs
     elseif a:type ==# 'nearest'
       let name = s:nearest_test(a:position)
       " if no tests matched, run the test file
-      return empty(name) ? fileargs : ['--focus='.shellescape(name, 1), path]
+      return empty(name) ? fileargs : ['--focus-file='.shellescape(name, 1), path]
     endif
   endif
 endfunction

--- a/spec/fixtures/ginkgo/normal_test.go
+++ b/spec/fixtures/ginkgo/normal_test.go
@@ -1,7 +1,7 @@
 package mypackage_test
 
 import (
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 

--- a/spec/ginkgo_spec.vim
+++ b/spec/ginkgo_spec.vim
@@ -16,28 +16,28 @@ describe "Ginkgo"
       view +17 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
+      Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./."
     end
 
     it "runs nearest tests identified by 'When'"
       view +29 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus='user is not logged in' ./."
+      Expect g:test#last_command == "ginkgo --focus-file='user is not logged in' ./."
     end
 
     it "runs nearest tests identified by 'Context'"
       view +11 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus='when the request is authenticated' ./."
+      Expect g:test#last_command == "ginkgo --focus-file='when the request is authenticated' ./."
     end
 
     it "runs nearest tests identified by 'Describe'"
       view +9 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus='posts API' ./."
+      Expect g:test#last_command == "ginkgo --focus-file='posts API' ./."
     end
 
   end
@@ -46,27 +46,27 @@ describe "Ginkgo"
     view +17 mypackage/normal_test.go
     TestNearest
 
-    Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./mypackage"
+    Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./mypackage"
   end
 
   it "runs file test if nearest test couldn't be found"
     view +1 mypackage/normal_test.go
     TestNearest
-    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=mypackage/normal_test.go ./mypackage"
+    Expect g:test#last_command == "ginkgo --focus-file=mypackage/normal_test.go ./mypackage"
   end
 
   it "runs file tests"
     view normal_test.go
     TestFile
 
-    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=normal_test.go ./."
+    Expect g:test#last_command == "ginkgo --focus-file=normal_test.go ./."
   end
 
   it "runs tests in subdirectory"
     view mypackage/normal_test.go
     TestFile
 
-    Expect g:test#last_command == "ginkgo --regexScansFilePath=true --focus=mypackage/normal_test.go ./mypackage"
+    Expect g:test#last_command == "ginkgo --focus-file=mypackage/normal_test.go ./mypackage"
   end
 
   it "runs test suites"
@@ -90,7 +90,7 @@ describe "Ginkgo"
       view +17 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
+      Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./."
     end
   end
 


### PR DESCRIPTION
Thank you so much for this AMAZING plugin!

This pull request updates the Ginkgo autoload to be compatible with v2.
Specifically, it:

- Removes `--focus` in favour of `--focus-file`, and
- Removes `--regexScansPath`, as `--focus-file` and `--skip-file` have
  deprecated it.

Signed-off-by: Carlos Nunez <13461447+carlosonunez@users.noreply.github.com>

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
