### PR TITLE
Support Go +build tags

### DIFF
--- a/spec/fixtures/gotest/build_tags_test.go
+++ b/spec/fixtures/gotest/build_tags_test.go
@@ -1,0 +1,15 @@
+// some comments are allowed before tags
+
+//go:build foo && hello && world && !bar && (red || black)
+// +build foo
+// +build hello,world
+// +build !bar
+// +build red black
+
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -73,4 +73,22 @@ describe "GoTest"
     Expect g:test#last_command == 'go test ./...'
   end
 
+  it "runs tests in a file with build tags"
+    view +14 build_tags_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -tags=foo,hello,world,!bar,red,black -run ''TestNumbers$'' ./.'
+
+    TestFile
+
+    Expect g:test#last_command == 'go test -tags=foo,hello,world,!bar,red,black'
+  end
+
+  it "runs test suite without tags"
+    view +14 build_tags_test.go
+    TestSuite
+
+    Expect g:test#last_command == 'go test ./...'
+  end
+
 end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`

When current file's got build tag constraints, by default it may not be
compiled by `go test`. This commit tries to parse the +build tags [1]
and add `-tags=foo,bar` to the command line.

The new go:build [2] is not supported since it's quite troublesome to
process. Users of Go 1.17+ can have both go:build and +build in a file
as long as they are consistent, or manually `:TestFile -tags=foo,bar`.

[1] https://pkg.go.dev/cmd/go@go1.16.15#hdr-Build_constraints
[2] https://pkg.go.dev/cmd/go@go1.18#hdr-Build_constraints
