### PR TITLE
Add support for Pest GWT plugin

### DIFF
--- a/autoload/test/php/pest.vim
+++ b/autoload/test/php/pest.vim
@@ -5,9 +5,9 @@ endif
 if !exists('g:test#php#pest#test_patterns')
   " Description for the tests:
   " https://pestphp.com/docs/writing-tests/
-  " Look for a function call that starts with "it" or "test"
+  " Look for a function call that starts with "it" or "test" or "scenario"
   let g:test#php#pest#test_patterns = {
-    \ 'test': ['\v^\s*%(it|test)[(]%("|'')(.*)%("|''),'],
+    \ 'test': ['\v^\s*%(it|test|scenario)[(]%("|'')(.*)%("|'')'],
     \ 'namespace': [],
   \}
 endif

--- a/spec/fixtures/pest/PestTest.php
+++ b/spec/fixtures/pest/PestTest.php
@@ -7,3 +7,7 @@ it('is a test case', function () {
 test('with a different descriptor', function () {
     //
 });
+
+scenario('bdd flavour')
+    ->when(fn () => true)
+    ->then(fn ($result) => true);

--- a/spec/pest_spec.vim
+++ b/spec/pest_spec.vim
@@ -33,6 +33,11 @@ describe "Pest"
     TestNearest
 
     Expect g:test#last_command == "pest --colors --filter 'with a different descriptor' PestTest.php"
+
+    view +12 PestTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'bdd flavour' PestTest.php"
   end
 
   it "runs test suites"


### PR DESCRIPTION
I've been using [this plugin](https://github.com/milroyfraser/pest-plugin-gwt) with pest but the patterns don't support it.

So this PR allows matching on the extra pattern.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
