### PR TITLE
cargotest: Use cargo to determine package name

### DIFF
--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -95,12 +95,20 @@ function! s:test_namespace(filename) abort
   endif
 
   let l:package = v:null
-  " Find package by searching upwards for Cargo.toml
+
+  " Find package by parsing cargo read-manifest output
+  let l:save_dir = chdir(fnamemodify(a:filename, ':p:h'))
+  if l:save_dir != ""
+    let l:json = system("cargo read-manifest")
+    let l:package = json_decode(l:json)['name']
+    call chdir(l:save_dir)
+  endif
+
+  " Cut modules to be relative to Cargo.toml
   for idx in range(len(l:modules) - 2, 0, -1)
       let l:cargo_toml = join(l:modules[:idx] + ['Cargo.toml'], '/')
       if !empty(glob(cargo_toml))
           echo 
-          let l:package = l:modules[idx]
           let l:modules = l:modules[idx+1:]
           break
       endif


### PR DESCRIPTION
Execute nearest fails when using a cargo workspace where the package name does not match the directory name fails. `cargotest.vim` uses the directory name, but a different package name can be specified in the `Cargo.toml`. 
This PR determines the package name using `cargo read-manifest`. 

A minimal example that is fixed by this PR:

Directory structure:
```
.
├── Cargo.toml
└── pack1
    ├── Cargo.toml
    └── src
        └── main.rs
```

`Cargo.toml`
```
[workspace]
members = [ "pack1", ]
```

`pack1/Cargo.toml`
```
[package]
name = "sim2"
version = "0.1.0"
edition = "2021"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
```

`pack1/src/main.rs`
```
fn main() {
    println!("Hello, world!");
}

// Execute nearest test on this line
#[test]
fn my_test() {}
```
