### PR TITLE
Add support for codeception .dist.yml

### DIFF
--- a/autoload/test/php/codeception.vim
+++ b/autoload/test/php/codeception.vim
@@ -5,7 +5,7 @@ endif
 
 function! test#php#codeception#test_file(file) abort
   if a:file =~# g:test#php#codeception#file_pattern
-    return filereadable('./codeception.yml')
+    return filereadable('./codeception.yml') || filereadable('./codeception.dist.yml')
   endif
 endfunction
 

--- a/spec/codeception_spec.vim
+++ b/spec/codeception_spec.vim
@@ -83,4 +83,16 @@ describe "Codeception"
     Expect exists('g:test#last_command') == 0
   end
 
+  it "also recognizes codeception.dist.yml"
+    try
+        !mv fixtures/codeception/codeception.yml fixtures/codeception/codeception.dist.yml
+        view tests/functional/NormalCest.php
+        TestFile
+
+        Expect g:test#last_command == 'codecept run tests/functional/NormalCest.php'
+    finally
+        !mv fixtures/codeception/codeception.dist.yml fixtures/codeception/codeception.yml
+    endtry
+  end
+
 end


### PR DESCRIPTION
Extend detection for codeception test file.
Respect codeception.dist.yml beside codeception.yml.

As documented by https://codeception.com/docs/reference/Configuration#Configuration-Templates-distyml

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
