### PR TITLE
Support go subtests

### DIFF
--- a/autoload/test/go.vim
+++ b/autoload/test/go.vim
@@ -1,6 +1,11 @@
 let test#go#patterns = {
-  \ 'test':      ['\v^\s*func ((Test|Example).*)\('],
-  \ 'namespace': [],
+  \ 'test': [
+    \ '\v^\s*func ((Test|Example).*)\(',
+    \ '\v^\s*t\.Run\("(.*)"',
+  \],
+  \ 'namespace': [
+    \ '\v^\s*func ((Test).*)\(',
+  \],
 \}
 function! test#go#test_file(runner, file_pattern, file) abort
   if fnamemodify(a:file, ':t') =~# a:file_pattern

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -55,5 +55,8 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#go#patterns)
-  return join(name['test'])
+  let name = join(name['namespace'] + name['test'], '/')
+  let without_spaces = substitute(name, '\s', '_', 'g')
+  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^]\)', '\\\1', 'g')
+  return escaped_regex
 endfunction

--- a/autoload/test/go/richgo.vim
+++ b/autoload/test/go/richgo.vim
@@ -31,5 +31,8 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#go#patterns)
-  return join(name['test'])
+  let name = join(name['namespace'] + name['test'], '/')
+  let without_spaces = substitute(name, '\s', '_', 'g')
+  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^]\)', '\\\1', 'g')
+  return escaped_regex
 endfunction

--- a/spec/fixtures/gotest/normal_test.go
+++ b/spec/fixtures/gotest/normal_test.go
@@ -2,8 +2,16 @@ package mypackage
 
 import "testing"
 
-func TestNumbers(*testing.T) {
+func TestNumbers(t *testing.T) {
 	// assertions
+
+	t.Run("adding two numbers", func(t *testing.T) {
+		// sub test assertions
+	})
+
+	t.Run("[].*+?|$^", func(t *testing.T) {
+		// sub test assertions
+	})
 }
 
 func Testテスト(*testing.T) {

--- a/spec/fixtures/richgo/normal_test.go
+++ b/spec/fixtures/richgo/normal_test.go
@@ -2,8 +2,16 @@ package mypackage
 
 import "testing"
 
-func TestNumbers(*testing.T) {
+func TestNumbers(t *testing.T) {
 	// assertions
+
+	t.Run("adding two numbers", func(t *testing.T) {
+		// sub test assertions
+	})
+
+	t.Run("[].*+?|$^", func(t *testing.T) {
+		// sub test assertions
+	})
 }
 
 func Testテスト(*testing.T) {

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -17,12 +17,23 @@ describe "GoTest"
 
     Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./.'
 
-    view +9 normal_test.go
+    view +8 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''TestNumbers/adding_two_numbers$'' ./.'
+
+    view +12 normal_test.go
+    TestNearest
+
+    let test_name = shellescape('\[\]\.\*\+\?\|\$\^')[1:-2]
+    Expect g:test#last_command == 'go test -run ''TestNumbers/'. test_name .'$'' ./.'
+
+    view +17 normal_test.go
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''Testテスト$'' ./.'
 
-    view +13 normal_test.go
+    view +21 normal_test.go
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''ExampleSomething$'' ./.'

--- a/spec/richgo_spec.vim
+++ b/spec/richgo_spec.vim
@@ -14,15 +14,29 @@ describe "RichGo"
   it "runs nearest tests"
     view +5 normal_test.go
     TestNearest
-    Expect g:test#last_command == "richgo test -run 'TestNumbers$' ./."
 
-    view +9 normal_test.go
-    TestNearest
-    Expect g:test#last_command == "richgo test -run 'Testテスト$' ./."
+    Expect g:test#last_command == 'richgo test -run ''TestNumbers$'' ./.'
 
-    view +13 normal_test.go
+    view +8 normal_test.go
     TestNearest
-    Expect g:test#last_command == "richgo test -run 'ExampleSomething$' ./."
+
+    Expect g:test#last_command == 'richgo test -run ''TestNumbers/adding_two_numbers$'' ./.'
+
+    view +12 normal_test.go
+    TestNearest
+
+    let test_name = shellescape('\[\]\.\*\+\?\|\$\^')[1:-2]
+    Expect g:test#last_command == 'richgo test -run ''TestNumbers/'. test_name .'$'' ./.'
+
+    view +17 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'richgo test -run ''Testテスト$'' ./.'
+
+    view +21 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'richgo test -run ''ExampleSomething$'' ./.'
   end
 
   it "runs nearest tests in subdirectory"


### PR DESCRIPTION
Makes `:TestNearest` work with `t.Run()` subtests in golang.

Since `-run` takes a regex, there's a need to escape characters. I could use some guidance with tests for for those, as it is a bit nasty. 😅

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly **no need?**
- [ ] Update the Vim documentation in `doc/test.txt` **no need?**
