### PR TITLE
Go subtests escape more characters

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -57,6 +57,6 @@ function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#go#patterns)
   let name = join(name['namespace'] + name['test'], '/')
   let without_spaces = substitute(name, '\s', '_', 'g')
-  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^]\)', '\\\1', 'g')
+  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^()]\)', '\\\1', 'g')
   return escaped_regex
 endfunction

--- a/autoload/test/go/richgo.vim
+++ b/autoload/test/go/richgo.vim
@@ -7,32 +7,13 @@ function! test#go#richgo#test_file(file) abort
 endfunction
 
 function! test#go#richgo#build_position(type, position) abort
-  if a:type ==# 'suite'
-    return ['./...']
-  else
-    let path = './'.fnamemodify(a:position['file'], ':h')
-
-    if a:type ==# 'file'
-      return path ==# './.' ? [] : [path . '/...']
-    elseif a:type ==# 'nearest'
-      let name = s:nearest_test(a:position)
-      return empty(name) ? [] : ['-run '.shellescape(name.'$', 1), path]
-    endif
-  endif
+  return test#go#gotest#build_position(a:type, a:position)
 endfunction
 
 function! test#go#richgo#build_args(args) abort
-  return a:args
+  return test#go#gotest#build_args(a:args)
 endfunction
 
 function! test#go#richgo#executable() abort
   return 'richgo test'
-endfunction
-
-function! s:nearest_test(position) abort
-  let name = test#base#nearest_test(a:position, g:test#go#patterns)
-  let name = join(name['namespace'] + name['test'], '/')
-  let without_spaces = substitute(name, '\s', '_', 'g')
-  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^()]\)', '\\\1', 'g')
-  return escaped_regex
 endfunction

--- a/autoload/test/go/richgo.vim
+++ b/autoload/test/go/richgo.vim
@@ -33,6 +33,6 @@ function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#go#patterns)
   let name = join(name['namespace'] + name['test'], '/')
   let without_spaces = substitute(name, '\s', '_', 'g')
-  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^]\)', '\\\1', 'g')
+  let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^()]\)', '\\\1', 'g')
   return escaped_regex
 endfunction

--- a/spec/fixtures/gotest/normal_test.go
+++ b/spec/fixtures/gotest/normal_test.go
@@ -9,7 +9,7 @@ func TestNumbers(t *testing.T) {
 		// sub test assertions
 	})
 
-	t.Run("[].*+?|$^", func(t *testing.T) {
+	t.Run("[].*+?|$^()", func(t *testing.T) {
 		// sub test assertions
 	})
 }

--- a/spec/fixtures/richgo/build_tags_test.go
+++ b/spec/fixtures/richgo/build_tags_test.go
@@ -1,0 +1,15 @@
+// some comments are allowed before tags
+
+//go:build foo && hello && world && !bar && (red || black)
+// +build foo
+// +build hello,world
+// +build !bar
+// +build red black
+
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}

--- a/spec/fixtures/richgo/normal_test.go
+++ b/spec/fixtures/richgo/normal_test.go
@@ -9,7 +9,7 @@ func TestNumbers(t *testing.T) {
 		// sub test assertions
 	})
 
-	t.Run("[].*+?|$^", func(t *testing.T) {
+	t.Run("[].*+?|$^()", func(t *testing.T) {
 		// sub test assertions
 	})
 }

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -101,5 +101,4 @@ describe "GoTest"
 
     Expect g:test#last_command == 'go test ./...'
   end
-
 end

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -25,7 +25,7 @@ describe "GoTest"
     view +12 normal_test.go
     TestNearest
 
-    let test_name = shellescape('\[\]\.\*\+\?\|\$\^')[1:-2]
+    let test_name = shellescape('\[\]\.\*\+\?\|\$\^\(\)')[1:-2]
     Expect g:test#last_command == 'go test -run ''TestNumbers/'. test_name .'$'' ./.'
 
     view +17 normal_test.go

--- a/spec/richgo_spec.vim
+++ b/spec/richgo_spec.vim
@@ -25,7 +25,7 @@ describe "RichGo"
     view +12 normal_test.go
     TestNearest
 
-    let test_name = shellescape('\[\]\.\*\+\?\|\$\^')[1:-2]
+    let test_name = shellescape('\[\]\.\*\+\?\|\$\^\(\)')[1:-2]
     Expect g:test#last_command == 'richgo test -run ''TestNumbers/'. test_name .'$'' ./.'
 
     view +17 normal_test.go

--- a/spec/richgo_spec.vim
+++ b/spec/richgo_spec.vim
@@ -76,4 +76,22 @@ describe "RichGo"
     TestSuite
     Expect g:test#last_command == 'richgo test ./...'
   end
+
+  it "runs tests in a file with build tags"
+    view +14 build_tags_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'richgo test -tags=foo,hello,world,!bar,red,black -run ''TestNumbers$'' ./.'
+
+    TestFile
+
+    Expect g:test#last_command == 'richgo test -tags=foo,hello,world,!bar,red,black'
+  end
+
+  it "runs test suite without tags"
+    view +14 build_tags_test.go
+    TestSuite
+
+    Expect g:test#last_command == 'richgo test ./...'
+  end
 end


### PR DESCRIPTION
- Fixes an issue where tests with `(` or `)` in their description would not be picked up correctly
- Reuse `gotest` implementation in `richgo` - they are essentially the same

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
