### PR TITLE
Allow for custom alternate file function

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,19 @@ You can disable this integration by doing
 let g:test#no_alternate = 1
 ```
 
+### Custom alternate file
+
+If you are using a different library for jumping between implementation and test file
+you can define a custom function that returns the test filename.
+
+```vim
+function! CustomAlternateFile(cmd)
+  return "test_file_spec.rb"
+endfunction
+
+let g:test#custom_alternate_file = function('echo')
+```
+
 ## Extending
 
 If you wish to extend this plugin with your own test runners, first of all,

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -152,6 +152,10 @@ function! s:alternate_file() abort
     let alternate_file = get(filter(projectionist#query_file('alternate'), 'filereadable(v:val)'), 0, '')
   endif
 
+  if empty(alternate_file) && has_key(g:, 'test#custom_alternate_file')
+    let alternate_file = g:test#custom_alternate_file()
+  endif
+
   if empty(alternate_file) && exists('g:loaded_rails') && !empty(rails#app())
     let alternate_file = rails#buffer().alternate()
   endif

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -670,6 +670,19 @@ You can disable this integration by doing
   let g:test#no_alternate = 1
 <
 
+CUSTOM ALTERNATE FILE                           *test-custom-alternate-file*
+
+If you are using a different library for jumping between implementation and test file
+you can define a custom function that returns the test filename.
+
+>
+function! CustomAlternateFile(cmd)
+  return "test_file_spec.rb"
+endfunction
+
+let g:test#custom_alternate_file = function('echo')
+<
+
 ABOUT                                           *test-about*
 
 You can get the latest version, see the changelog, or report a bug on GitHub:


### PR DESCRIPTION
Hopefully this could be helpful for somebody else.
I'm using https://github.com/rgroli/other.nvim and wanted to integrate with it.
Not sure if this needs a test, my first time touching vimscript really :shushing_face: 

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
