### PR TITLE
Support executing maven wrapper on Java tests

### DIFF
--- a/autoload/test/java/maventest.vim
+++ b/autoload/test/java/maventest.vim
@@ -41,7 +41,10 @@ function! test#java#maventest#build_args(args) abort
 endfunction
 
 function! test#java#maventest#executable() abort
-  return 'mvn'
+  if findfile('mvnw') ==# 'mvnw'
+    return './mvnw'
+  else
+    return 'mvn'
 endfunction
 
 function! s:get_java_package(filepath)

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/.gitignore
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/.gitignore
@@ -1,0 +1,4 @@
+target/*
+.classpath
+.project
+.settings/*

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/.mvn/wrapper/maven-wrapper.properties
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/mvnw
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/mvnw
@@ -1,0 +1,227 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Maven2 Start Up Batch script
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   M2_HOME - location of maven2's installed home dir
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ] ; then
+
+  if [ -f /etc/mavenrc ] ; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ] ; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false;
+darwin=false;
+mingw=false
+case "`uname`" in
+  CYGWIN*) cygwin=true ;;
+  MINGW*) mingw=true;;
+  Darwin*) darwin=true
+    # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+    # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+    if [ -z "$JAVA_HOME" ]; then
+      if [ -x "/usr/libexec/java_home" ]; then
+        export JAVA_HOME="`/usr/libexec/java_home`"
+      else
+        export JAVA_HOME="/Library/Java/Home"
+      fi
+    fi
+    ;;
+esac
+
+if [ -z "$JAVA_HOME" ] ; then
+  if [ -r /etc/gentoo-release ] ; then
+    JAVA_HOME=`java-config --jre-home`
+  fi
+fi
+
+if [ -z "$M2_HOME" ] ; then
+  ## resolve links - $0 may be a link to maven's home
+  PRG="$0"
+
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="`dirname "$PRG"`/$link"
+    fi
+  done
+
+  saveddir=`pwd`
+
+  M2_HOME=`dirname "$PRG"`/..
+
+  # make it fully qualified
+  M2_HOME=`cd "$M2_HOME" && pwd`
+
+  cd "$saveddir"
+  # echo Using m2 at $M2_HOME
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --unix "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME="`(cd "$M2_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="`which javac`"
+  if [ -n "$javaExecutable" ] && ! [ "`expr \"$javaExecutable\" : '\([^ ]*\)'`" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=`which readlink`
+    if [ ! `expr "$readLink" : '\([^ ]*\)'` = "no" ]; then
+      if $darwin ; then
+        javaHome="`dirname \"$javaExecutable\"`"
+        javaExecutable="`cd \"$javaHome\" && pwd -P`/javac"
+      else
+        javaExecutable="`readlink -f \"$javaExecutable\"`"
+      fi
+      javaHome="`dirname \"$javaExecutable\"`"
+      javaHome=`expr "$javaHome" : '\(.*\)/bin'`
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="`which java`"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ] ; then
+  echo "Warning: JAVA_HOME environment variable is not set."
+fi
+
+CLASSWORLDS_LAUNCHER=org.codehaus.plexus.classworlds.launcher.Launcher
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+
+  if [ -z "$1" ]
+  then
+    echo "Path not specified to find_maven_basedir"
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ] ; do
+    if [ -d "$wdir"/.mvn ] ; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=`cd "$wdir/.."; pwd`
+    fi
+    # end of workaround
+  done
+  echo "${basedir}"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    echo "$(tr -s '\n' ' ' < "$1")"
+  fi
+}
+
+BASE_DIR=`find_maven_basedir "$(pwd)"`
+if [ -z "$BASE_DIR" ]; then
+  exit 1;
+fi
+
+export MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+if [ "$MVNW_VERBOSE" = true ]; then
+  echo $MAVEN_PROJECTBASEDIR
+fi
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$M2_HOME" ] &&
+    M2_HOME=`cygpath --path --windows "$M2_HOME"`
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME=`cygpath --path --windows "$JAVA_HOME"`
+  [ -n "$CLASSPATH" ] &&
+    CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  [ -n "$MAVEN_PROJECTBASEDIR" ] &&
+    MAVEN_PROJECTBASEDIR=`cygpath --path --windows "$MAVEN_PROJECTBASEDIR"`
+fi
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.home=${M2_HOME}" "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/pom.xml
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.vimtest</groupId>
+    <artifactId>vimtest</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>sample_maven_project</name>
+    <url>http://maven.apache.org</url>
+    <dependencies>
+        <!-- Junit5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.4.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/src/main/java/org/vimtest/App.java
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/src/main/java/org/vimtest/App.java
@@ -1,0 +1,19 @@
+package org.vimtest;
+
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+
+    public Integer add(Integer a, Integer b)
+    {
+        return a + b;
+    }
+}

--- a/spec/fixtures/maven/sample_maven_junit5_mvnw_project/src/test/java/org/vimtest/TestApp.java
+++ b/spec/fixtures/maven/sample_maven_junit5_mvnw_project/src/test/java/org/vimtest/TestApp.java
@@ -1,0 +1,42 @@
+package org.vimtest;
+
+import org.vimtest.App;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Assertions;
+
+
+public class TestApp 
+{
+    @Test void test_testdecorator_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test public void test_testdecorator_public_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    void test_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_public_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Nested
+    class Test_NestedTestClass
+    {
+        @Test
+        public void test_nested_test()
+        {
+            Assertions.assertEquals(true, true);
+        }
+    }
+}

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -197,6 +197,64 @@ describe "Maven Junit5 tests"
 
 end
 
+
+describe "Maven Junit5 tests (mvnw)"
+
+  before
+    cd spec/fixtures/maven/sample_maven_junit5_mvnw_project
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "TestFile runs with package-path, with asterisk to catch nested-test-classes"
+    view +14 src/test/java/org/vimtest/TestApp.java
+    TestFile
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\*'
+  end
+
+  it "TestNearest - @Test void func()"
+    view +12 src/test/java/org/vimtest/TestApp.java
+    TestNearest
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\#test_testdecorator_void'
+  end
+
+  it "TestNearest - @Test public void func()"
+    view +17 src/test/java/org/vimtest/TestApp.java
+    TestNearest
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\#test_testdecorator_public_void'
+  end
+
+  it "TestNearest - void func()"
+    view +22 src/test/java/org/vimtest/TestApp.java
+    TestNearest
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\#test_void'
+  end
+
+  it "TestNearest - public void func()"
+    view +30 src/test/java/org/vimtest/TestApp.java
+    TestNearest
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\#test_public_void'
+  end
+
+  it "TestNearest - nested test()"
+    view +39 src/test/java/org/vimtest/TestApp.java
+    TestNearest
+
+    Expect g:test#last_command == './mvnw test -Dtest=org.vimtest.TestApp\$Test_NestedTestClass\#test_nested_test'
+  end
+
+end
+
+
+
 describe "Maven Junit5 multimodule tests"
 
   before


### PR DESCRIPTION
Although groovy tests support mvnw executable, java tests have not supported it.
When the vim-test can find the mvnw executable, it will run the test with mvnw.

-----

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
