### PR TITLE
Fix normal mode start for basic strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -6,7 +6,7 @@ function! test#strategy#basic(cmd) abort
   if has('nvim')
     -tabnew
     call termopen(a:cmd)
-    if !get(g:, 'test:basic:start_normal', 0)
+    if !get(g:, 'test#basic#start_normal', 0)
       startinsert
     endif
   else


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner (Not applicable)
- [x] Update the README accordingly (Not applicable)
- [x] Update the Vim documentation in `doc/test.txt` (Not applicable)

## Fix normal mode start for basic strategy

In #578, starting in normal mode was introduced, but due to a typo, it does not work for basic strategy. This PR fixes that.
