### PR TITLE
Fix typo in variable name

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -175,7 +175,7 @@ function! test#strategy#harpoon(cmd) abort
   lua require("harpoon.term").sendCommand(vim.api.nvim_eval("l:harpoon_term"), vim.g.cmd)
   let goToTerminal = exists("g:test#harpoon#gototerminal") ? g:test#harpoon#gototerminal : 1
   if goToTerminal
-    lua require("harpoon.term").gotoTerminal(vim.api.nvim_eval("l:term"))
+    lua require("harpoon.term").gotoTerminal(vim.api.nvim_eval("l:harpoon_term"))
   endif
 endfunction
 


### PR DESCRIPTION
Fixes a bug introduced in a5b122e8c5eb47db5a034908172ccbee44f4e520 where it will crash due to unknown variable
