### PR TITLE
fix: Ginkgo call `Nearest` failures

### DIFF
--- a/autoload/test/go/ginkgo.vim
+++ b/autoload/test/go/ginkgo.vim
@@ -21,7 +21,7 @@ function! test#go#ginkgo#build_position(type, position) abort
     elseif a:type ==# 'nearest'
       let name = s:nearest_test(a:position)
       " if no tests matched, run the test file
-      return empty(name) ? fileargs : ['--focus-file='.shellescape(name, 1), path]
+      return empty(name) ? fileargs : ['--focus='.shellescape(name, 1), path]
     endif
   endif
 endfunction

--- a/spec/fixtures/ginkgo/normal_test.go
+++ b/spec/fixtures/ginkgo/normal_test.go
@@ -29,7 +29,7 @@ var _ = Describe("posts API", func() {
 	When("user is not logged in", func() {
 
 		It("should deny access", func() {
-
+			Expect(true).To(BeTrue())
 		})
 	})
 

--- a/spec/ginkgo_spec.vim
+++ b/spec/ginkgo_spec.vim
@@ -16,28 +16,28 @@ describe "Ginkgo"
       view +17 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./."
+      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
     end
 
     it "runs nearest tests identified by 'When'"
       view +29 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus-file='user is not logged in' ./."
+      Expect g:test#last_command == "ginkgo --focus='user is not logged in' ./."
     end
 
     it "runs nearest tests identified by 'Context'"
       view +11 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus-file='when the request is authenticated' ./."
+      Expect g:test#last_command == "ginkgo --focus='when the request is authenticated' ./."
     end
 
     it "runs nearest tests identified by 'Describe'"
       view +9 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus-file='posts API' ./."
+      Expect g:test#last_command == "ginkgo --focus='posts API' ./."
     end
 
   end
@@ -46,7 +46,7 @@ describe "Ginkgo"
     view +17 mypackage/normal_test.go
     TestNearest
 
-    Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./mypackage"
+    Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./mypackage"
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -90,7 +90,7 @@ describe "Ginkgo"
       view +17 normal_test.go
       TestNearest
 
-      Expect g:test#last_command == "ginkgo --focus-file='should paginate the result' ./."
+      Expect g:test#last_command == "ginkgo --focus='should paginate the result' ./."
     end
   end
 


### PR DESCRIPTION
1. ginkgo v2 support args `--focus`.
Ref: https://github.com/onsi/ginkgo/blob/v2.1.4/types/config.go#L282-L283

```
➜  ~ ginkgo version
Ginkgo Version 2.1.4
➜  ~ ginkgo help run | grep -A3 -- '--focus'
  --focus [string]
    If set, ginkgo will only run specs that match this regular expression. Can
    be specified multiple times, values are ORed.
  --skip [string]
```

2. Use parameter `--focus-file` for `name` will not match any case.

3. Reproduce and compare
```
➜  cd spec/fixtures/ginkgo/

➜ ginkgo git:(master) ✗ go mod init test

go: creating new go.mod: module test
go: to add module requirements and sums:
	go mod tidy
➜  ginkgo git:(master) ✗ go mod tidy
go: finding module for package github.com/onsi/ginkgo
go: finding module for package github.com/onsi/ginkgo/v2
go: finding module for package github.com/onsi/gomega
go: found github.com/onsi/ginkgo/v2 in github.com/onsi/ginkgo/v2 v2.1.4
go: found github.com/onsi/gomega in github.com/onsi/gomega v1.20.0
go: found github.com/onsi/ginkgo in github.com/onsi/ginkgo v1.16.5

➜  ginkgo git:(master) ✗ ginkgo bootstrap
Generating ginkgo test suite bootstrap for mypackage in:
	ginkgo_suite_test.go

➜  ginkgo git:(master) ✗ ginkgo version
Ginkgo Version 2.1.4

➜  ginkgo git:(fix/ginkgo-v2-focus) ✗ ginkgo --focus='should paginate the result' ./.
Running Suite: Ginkgo Suite - /Users/xxx/code/github/l-qing/vim-test/spec/fixtures/ginkgo
=============================================================================================
Random Seed: 1659974525

Will run 1 of 4 specs
S•SS

Ran 1 of 4 Specs in 0.000 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 3 Skipped
PASS

Ginkgo ran 1 suite in 916.889658ms
Test Suite Passed

➜  ginkgo git:(fix/ginkgo-v2-focus) ✗ ginkgo --focus-file='should paginate the result' ./.
Running Suite: Ginkgo Suite - /Users/xxx/code/github/l-qing/vim-test/spec/fixtures/ginkgo
=============================================================================================
Random Seed: 1659974529

Will run 0 of 4 specs
SSSS

Ran 0 of 4 Specs in 0.000 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

Ginkgo ran 1 suite in 860.609998ms
Test Suite Passed

```

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
