### PR TITLE
Uses elm-test in node_modules if available

### DIFF
--- a/autoload/test/elm/elmtest.vim
+++ b/autoload/test/elm/elmtest.vim
@@ -26,5 +26,9 @@ function! test#elm#elmtest#build_args(args) abort
 endfunction
 
 function! test#elm#elmtest#executable() abort
-  return 'elm-test'
+  if filereadable('node_modules/.bin/elm-test')
+    return 'node_modules/.bin/elm-test'
+  else
+    return 'elm-test'
+  endif
 endfunction

--- a/autoload/test/elm/elmtest.vim
+++ b/autoload/test/elm/elmtest.vim
@@ -27,7 +27,8 @@ endfunction
 
 function! test#elm#elmtest#executable() abort
   if filereadable('node_modules/.bin/elm-test')
-    return 'node_modules/.bin/elm-test'
+    return 'node_modules/.bin/elm-test' .
+      \ filereadable('node_modules/.bin/elm') ? ' --compiler node_modules/.bin/elm' : ''
   else
     return 'elm-test'
   endif

--- a/autoload/test/elm/elmtest.vim
+++ b/autoload/test/elm/elmtest.vim
@@ -28,7 +28,7 @@ endfunction
 function! test#elm#elmtest#executable() abort
   if filereadable('node_modules/.bin/elm-test')
     return 'node_modules/.bin/elm-test' .
-      \ filereadable('node_modules/.bin/elm') ? ' --compiler node_modules/.bin/elm' : ''
+      \ (filereadable('node_modules/.bin/elm') ? ' --compiler node_modules/.bin/elm' : '')
   else
     return 'elm-test'
   endif

--- a/spec/elmtest_spec.vim
+++ b/spec/elmtest_spec.vim
@@ -32,18 +32,36 @@ describe "elm-test"
   end
 
   it "runs tests against absolute path of npm executable (elm-test)"
-    let g:test#javascript#elm#executable = 'node_modules/.bin/elm-test'
-    view tests/NormalTest.elm
-    TestFile
+    try
+      !mkdir -p node_modules/.bin
+      !touch node_modules/.bin/elm-test
 
-    Expect g:test#last_command == 'node_modules/.bin/elm-test tests/NormalTest.elm'
+      view tests/NormalTest.elm
+      TestFile
+
+      Expect g:test#last_command == 'node_modules/.bin/elm-test tests/NormalTest.elm'
+    finally
+      !rm node_modules/.bin/elm-test
+      !rmdir node_modules/.bin
+      !rmdir node_modules
+    endtry
   end
 
   it "runs tests against absolute path of npm executable (elm-test and elm-compiler)"
-    let g:test#javascript#elm#executable = 'node_modules/.bin/elm-test --compiler node_modules/.bin/elm'
-    view tests/NormalTest.elm
-    TestFile
+    try
+      !mkdir -p node_modules/.bin
+      !touch node_modules/.bin/elm-test
+      !touch node_modules/.bin/elm
 
-    Expect g:test#last_command == 'node_modules/.bin/elm-test --compiler node_modules/.bin/elm tests/NormalTest.elm'
+      view tests/NormalTest.elm
+      TestFile
+
+      Expect g:test#last_command == 'node_modules/.bin/elm-test --compiler node_modules/.bin/elm tests/NormalTest.elm'
+    finally
+      !rm node_modules/.bin/elm-test
+      !rm node_modules/.bin/elm
+      !rmdir node_modules/.bin
+      !rmdir node_modules
+    endtry
   end
 end

--- a/spec/elmtest_spec.vim
+++ b/spec/elmtest_spec.vim
@@ -31,4 +31,19 @@ describe "elm-test"
     Expect g:test#last_command == 'elm-test'
   end
 
+  it "runs tests against absolute path of npm executable (elm-test)"
+    let g:test#javascript#elm#executable = 'node_modules/.bin/elm-test'
+    view tests/NormalTest.elm
+    TestFile
+
+    Expect g:test#last_command == 'node_modules/.bin/elm-test tests/NormalTest.elm'
+  end
+
+  it "runs tests against absolute path of npm executable (elm-test and elm-compiler)"
+    let g:test#javascript#elm#executable = 'node_modules/.bin/elm-test --compiler node_modules/.bin/elm'
+    view tests/NormalTest.elm
+    TestFile
+
+    Expect g:test#last_command == 'node_modules/.bin/elm-test --compiler node_modules/.bin/elm tests/NormalTest.elm'
+  end
 end


### PR DESCRIPTION
Elm runner does not cover the case that users install elm executables as their local dependecies.

This PR adds it.

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
