### PR TITLE
Fix non-standard function declaration within kitty strategy and cleanup shellcheck warnings

### DIFF
--- a/bin/kitty_runner
+++ b/bin/kitty_runner
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 # Starting this Kitty version, use launch command to create a vim-output window
 KITTY_LAUNCH_VERSION="0.26.0"
@@ -11,7 +11,7 @@ KITTY_VERSION=$(kitty --version | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
 # Kitty command to launch a new window
 KITTY_NEW_WINDOW="new-window"
 
-if [ $(version $KITTY_VERSION) -ge $(version $KITTY_LAUNCH_VERSION) ]; then
+if [ "$(version "$KITTY_VERSION")" -ge "$(version "$KITTY_LAUNCH_VERSION")" ]; then
   KITTY_NEW_WINDOW="launch"
 fi
 
@@ -21,4 +21,3 @@ then
 fi
 
 kitty @ --to "$KITTY_LISTEN_ON" send-text --match title:"vim-test-output" "$1\x0d"
-


### PR DESCRIPTION
Addition of non-standard function declaration broke kitty strategy from commit d7008abc25c5593e3d204d5b9508645fd40187e8 onward. This standardizes the function declaration and cleans up some warnings listed in [ShellCheck](https://www.shellcheck.net/).
