### PR TITLE
Make `:TestNearest` work with nested tests in golang

### DIFF
--- a/autoload/test/go.vim
+++ b/autoload/test/go.vim
@@ -6,6 +6,7 @@ let test#go#patterns = {
   \],
   \ 'namespace': [
     \ '\v^\s*func ((Test).*)\(',
+    \ '\v^\s*t\.Run\("(.*)"',
   \],
 \}
 function! test#go#test_file(runner, file_pattern, file) abort

--- a/spec/fixtures/gotest/normal_test.go
+++ b/spec/fixtures/gotest/normal_test.go
@@ -12,6 +12,12 @@ func TestNumbers(t *testing.T) {
 	t.Run("[].*+?|$^()", func(t *testing.T) {
 		// sub test assertions
 	})
+
+	t.Run("this is", func(t *testing.T) {
+		t.Run("nested", func(t *testing.T) {
+			// nested test assertions
+		})
+	})
 }
 
 func Testテスト(*testing.T) {

--- a/spec/fixtures/gotest/normal_test.go
+++ b/spec/fixtures/gotest/normal_test.go
@@ -33,6 +33,6 @@ func Something() {
 
 type TestSomeTestifySuite struct{}
 
-func (suite *TestSomeTestifySuite) TestSomething() {
+func (suite *TestSomeTestifySuite) TestSomethingInASuite() {
 	// assertions
 }

--- a/spec/fixtures/richgo/normal_test.go
+++ b/spec/fixtures/richgo/normal_test.go
@@ -12,6 +12,12 @@ func TestNumbers(t *testing.T) {
 	t.Run("[].*+?|$^()", func(t *testing.T) {
 		// sub test assertions
 	})
+
+	t.Run("this is", func(t *testing.T) {
+		t.Run("nested", func(t *testing.T) {
+			// nested test assertions
+		})
+	})
 }
 
 func Testテスト(*testing.T) {

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -42,6 +42,11 @@ describe "GoTest"
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''ExampleSomething$'' ./.'
+
+    view +36 normal_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''TestSomethingInASuite$'' ./.'
   end
 
   it "runs nearest tests in subdirectory"

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -31,17 +31,17 @@ describe "GoTest"
     view +17 normal_test.go
     TestNearest
 
+    Expect g:test#last_command == 'go test -run ''TestNumbers/this_is/nested$'' ./.'
+
+    view +23 normal_test.go
+    TestNearest
+
     Expect g:test#last_command == 'go test -run ''Testテスト$'' ./.'
 
-    view +21 normal_test.go
+    view +27 normal_test.go
     TestNearest
 
     Expect g:test#last_command == 'go test -run ''ExampleSomething$'' ./.'
-
-    view +30 normal_test.go
-    TestNearest
-
-    Expect g:test#last_command == 'go test -run ''TestSomething$'' ./.'
   end
 
   it "runs nearest tests in subdirectory"

--- a/spec/richgo_spec.vim
+++ b/spec/richgo_spec.vim
@@ -31,9 +31,14 @@ describe "RichGo"
     view +17 normal_test.go
     TestNearest
 
+    Expect g:test#last_command == 'richgo test -run ''TestNumbers/this_is/nested$'' ./.'
+
+    view +23 normal_test.go
+    TestNearest
+
     Expect g:test#last_command == 'richgo test -run ''Testテスト$'' ./.'
 
-    view +21 normal_test.go
+    view +27 normal_test.go
     TestNearest
 
     Expect g:test#last_command == 'richgo test -run ''ExampleSomething$'' ./.'


### PR DESCRIPTION
Right now, when attempting to `:TestNearest` a nested test, such as:

```go
function TestSomething() {
  t.Run("foo", function() {
    t.Run("bar", function() {
      // execute :TestNearest here
    })
  })
}
``` 

vim-test will run `TestSomething/foo`, while it should run `TestSomething/foo/bar`. 

This PR makes vim-test pick up nested tests correctly.

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
