### PR TITLE
Support default cypress extension type

### DIFF
--- a/autoload/test/javascript/cypress.vim
+++ b/autoload/test/javascript/cypress.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#cypress#file_pattern')
-  let g:test#javascript#cypress#file_pattern = '\v(__tests__/.*|(spec|test))\.(js|jsx|coffee|ts|tsx)$'
+  let g:test#javascript#cypress#file_pattern = '\v(__tests__/.*|(spec|test|cy))\.(js|jsx|coffee|ts|tsx)$'
 endif
 
 function! test#javascript#cypress#test_file(file) abort

--- a/spec/cypress_spec.vim
+++ b/spec/cypress_spec.vim
@@ -11,11 +11,25 @@ describe "Cypress"
     cd -
   end
 
-  it "runs file tests"
+  it "runs spec file tests"
     view integration_tests/normal.spec.js
     TestFile
 
     Expect g:test#last_command == 'cypress run --spec integration_tests/normal.spec.js'
+  end
+
+  it "runs cy file tests"
+    view integration_tests/normal.cy.js
+    TestFile
+
+    Expect g:test#last_command == 'cypress run --spec integration_tests/normal.cy.js'
+  end
+
+  it "runs test file tests"
+    view integration_tests/normal.test.js
+    TestFile
+
+    Expect g:test#last_command == 'cypress run --spec integration_tests/normal.test.js'
   end
 
   it "runs test suites"

--- a/spec/fixtures/cypress/integration_tests/normal.cy.js
+++ b/spec/fixtures/cypress/integration_tests/normal.cy.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  describe(`Addition`, function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});

--- a/spec/fixtures/cypress/integration_tests/normal.test.js
+++ b/spec/fixtures/cypress/integration_tests/normal.test.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  describe(`Addition`, function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});


### PR DESCRIPTION
I use cypress in my workplace and we've recently moved to the default naming
convention specified by some cypress config.

This PR moves vim-test to support this file naming structure.

- Support .cy.{js,jsx,coffee} file suffix type
- Adds fixtures for cy and test file suffix types
- Adds coverage for cy and test file types

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
