### PR TITLE
add spec and fixture for rust nested test modules

### DIFF
--- a/spec/cargonextest_spec.vim
+++ b/spec/cargonextest_spec.vim
@@ -115,6 +115,20 @@ describe "CargoNextest"
     Expect g:test#last_command == 'cargo nextest run ''too::nested::tests::second_test'''
   end
 
+  it "runs nearest test in nested test modules"
+    view +3 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo nextest run ''nested_tests::tests::first_test'''
+
+    view +8 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo nextest run ''nested_tests::tests::nested_once::second_test'''
+
+    view +13 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo nextest run ''nested_tests::tests::nested_once::nested_twice::third_test'''
+  end
+
   it "runs test suites"
     view src/lib.rs
     TestSuite

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -115,6 +115,20 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --exact'
   end
 
+  it "runs nearest test in nested test modules"
+    view +3 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested_tests::tests::first_test'' -- --exact'
+
+    view +8 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested_tests::tests::nested_once::second_test'' -- --exact'
+
+    view +13 src/nested_tests.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested_tests::tests::nested_once::nested_twice::third_test'' -- --exact'
+  end
+
   it "runs test suites"
     view src/lib.rs
     TestSuite

--- a/spec/fixtures/cargo/crate/src/nested_tests.rs
+++ b/spec/fixtures/cargo/crate/src/nested_tests.rs
@@ -1,0 +1,17 @@
+mod tests {
+    #[test]
+    fn first_test() {
+    }
+
+    mod nested_once {
+        #[test]
+        fn second_test() {
+        }
+
+        mod nested_twice {
+            #[test]
+            fn third_test() {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
  - _Didn't, I don't think necessary._
- [x] Update the Vim documentation in `doc/test.txt`
  - _Didn't, I don't think necessary._

The added failing spec demonstrates the issue https://github.com/vim-test/vim-test/issues/708 

vim-test isn't running the correct test command for rust files, with both cargo test and nextest, when tests in a single file are nested inside modules. The linked issue has an example.
