### PR TITLE
Python: Use explicit Python3 in invocation

### DIFF
--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -39,7 +39,11 @@ function! test#python#pyunit#executable() abort
     let pipenv_prefix = "pipenv run "
   endif
 
-  return pipenv_prefix . 'python3 -m unittest'
+  if strlen(system('command -v python3'))
+    return pipenv_prefix . 'python3 -m unittest'
+  else
+    return pipenv_prefix . 'python -m unittest'
+  endif
 endfunction
 
 function! s:get_import_path(filepath) abort

--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -39,7 +39,7 @@ function! test#python#pyunit#executable() abort
     let pipenv_prefix = "pipenv run "
   endif
 
-  return pipenv_prefix . 'python -m unittest'
+  return pipenv_prefix . 'python3 -m unittest'
 endfunction
 
 function! s:get_import_path(filepath) abort

--- a/spec/pyunit_pipenv_spec.vim
+++ b/spec/pyunit_pipenv_spec.vim
@@ -16,21 +16,21 @@ describe "PyUnit with Pipenv"
     view +1 test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'pipenv run python -m unittest test_class.TestNumbers'
+    Expect g:test#last_command == 'pipenv run python3 -m unittest test_class.TestNumbers'
   end
 
   it "runs file tests"
     view test_class.py
     TestFile
 
-    Expect g:test#last_command == 'pipenv run python -m unittest test_class'
+    Expect g:test#last_command == 'pipenv run python3 -m unittest test_class'
   end
 
   it "runs test suites"
     view test_class.py
     TestSuite
 
-    Expect g:test#last_command == 'pipenv run python -m unittest'
+    Expect g:test#last_command == 'pipenv run python3 -m unittest'
   end
 
 end

--- a/spec/pyunit_spec.vim
+++ b/spec/pyunit_spec.vim
@@ -16,27 +16,27 @@ describe "PyUnitTest"
     view +2 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestNumbers.test_numbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestNumbers.test_numbers'
 
     view +5 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestSubclass'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestSubclass'
 
     view +1 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestNumbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestNumbers'
 
     view +15 module/test_class.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_class.TestNestedClass.test_nested'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class.TestNestedClass.test_nested'
 
     view +1 module/test_method.py
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_method.test_numbers'
+    Expect g:test#last_command == 'python3 -m unittest module.test_method.test_numbers'
   end
 
   it "runs file test if nearest test couldn't be found"
@@ -44,21 +44,21 @@ describe "PyUnitTest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'python -m unittest module.test_method'
+    Expect g:test#last_command == 'python3 -m unittest module.test_method'
   end
 
   it "runs file tests"
     view module/test_class.py
     TestFile
 
-    Expect g:test#last_command == 'python -m unittest module.test_class'
+    Expect g:test#last_command == 'python3 -m unittest module.test_class'
   end
 
   it "runs test suites"
     view test_class.py
     TestSuite
 
-    Expect g:test#last_command == 'python -m unittest'
+    Expect g:test#last_command == 'python3 -m unittest'
   end
 
 end


### PR DESCRIPTION
This is necessary since some platforms such as MacOS have no explicit alias for python.
