### PR TITLE
phpunit: handle attributes added in phpunit 10

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -7,11 +7,13 @@ if !exists('g:test#php#phpunit#test_patterns')
   " 1: Look for a public method which name starts with "test"
   " 2: Look for a phpdoc tag "@test" (on a line by itself)
   " 3: Look for a phpdoc block on one line containg the "@test" tag
+  " 4: Look for an attribute "#[Test]" or "#[Test," (on a line by itself)
   let g:test#php#phpunit#test_patterns = {
     \ 'test': [
       \ '\v^\s*public function (test\w+)\(',
       \ '\v^\s*\*\s*(\@test)',
       \ '\v^\s*\/\*\*\s*(\@test)\s*\*\/',
+      \ '\v^\s*(#\[\s*Test\s*[,\]])',
     \],
     \ 'namespace': [],
   \}
@@ -67,7 +69,8 @@ function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#php#phpunit#test_patterns)
 
   " If we found the '@test' docblock
-  if !empty(name['test']) && '@test' == name['test'][0]
+  echomsg name
+  if !empty(name['test']) && ('@test' == name['test'][0] || '#' == name['test'][0][0])
     " Search forward for the first declared public method
     let name = test#base#nearest_test_in_lines(
       \ a:position['file'],

--- a/spec/fixtures/phpunit/NormalTest.php
+++ b/spec/fixtures/phpunit/NormalTest.php
@@ -82,4 +82,25 @@ class NormalTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(2, 4-21);
     }
+
+    #[Test]
+    public function aTestMarkedWithTestAttributeOnOneLine()
+    {
+        $this->assertEquals(2, 4-21);
+    }
+
+    #[Test,TestWith([2, 4-21])]
+    public function aTestMarkedWithTestAttributeInGroupOnOneLine(int $expected, int $value)
+    {
+        $this->assertEquals($expected, $value);
+    }
+
+    #[
+        Test,
+        TestWith([2, 4-21]),
+    ]
+    public function aTestMarkedWithTestAttributeInGroupOnMultipleLines(int $expected, int $value)
+    {
+        $this->assertEquals($expected, $value);
+    }
 }

--- a/spec/phpunit_spec.vim
+++ b/spec/phpunit_spec.vim
@@ -72,6 +72,28 @@ describe "PHPUnit"
     Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAnnotationOnOneLine' NormalTest.php"
   end
 
+  it "runs nearest test with a one line #[Test] attribute"
+    view +87 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAttributeOnOneLine' NormalTest.php"
+  end
+
+  it "runs nearest test with a one line #[Test] attribute in a group"
+    view +93 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAttributeInGroupOnOneLine' NormalTest.php"
+  end
+
+  " Skipped because I didn't managed to find a way to make it work without allowing false positive
+  " it "runs nearest test with a multi lines #[Test] attribute in a group"
+  "   view +102 NormalTest.php
+  "   TestNearest
+
+  "   Expect g:test#last_command == "phpunit --colors --filter '::aTestMarkedWithTestAttributeInGroupOnMultipleLines' NormalTest.php"
+  " end
+
   it "runs test suites"
     view NormalTest.php
     TestSuite


### PR DESCRIPTION
I left a commented test because I was not able to make it work reliably. As the fixtures shows it would mean matching a line with only `Test,` on it and that could be any comment or string on multiple lines as well.
Since this is an optional syntax and we can add as many attributes as possible I decided to not take the chance.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
