### PR TITLE
Enable toggle term to execute kotlin backticks test methods

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -98,7 +98,7 @@ function! test#strategy#neoterm(cmd) abort
 endfunction
 
 function! test#strategy#toggleterm(cmd) abort
-  execute 'TermExec cmd="'.a:cmd.'"'
+  execute "TermExec cmd='".a:cmd."'"
 endfunction
 
 function! test#strategy#floaterm(cmd) abort


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

Currently, running `TestNearest -strategy=toggleterm` on the [Kotlin backticks method ](https://kotlinlang.org/docs/coding-conventions.html#names-for-test-methods)fails because `TermExec cmd=""` is using double quotes in the command. According to the [documentation](https://github.com/akinsho/toggleterm.nvim/blob/main/doc/toggleterm.txt) for TermExec , we have to use quotes. Using the double quotes in this case cause the command to be prematurely terminated when a test name containing double quotes is encountered. This results in all tests in the class being run instead of just the nearest test.

To resolve this issue, I just change the double quotes to single quotes at the start of the command. This will allow the command to properly execute the nearest test without being prematurely terminated by any quotes in the test name.



i don`t think that have to update README or documentation.