### PR TITLE
add `g:test#rust#cargotest#test_options` for custom cargo test_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ If you want some CLI options to stick around, you can configure them in your
 
 ```vim
 let test#ruby#minitest#options = '--verbose'
+let test#rust#cargotest#test_options = '-- --nocapture'
 ```
 
 You can also choose a more granular approach:
@@ -355,6 +356,10 @@ let test#ruby#rspec#options = {
   \ 'nearest': '--backtrace',
   \ 'file':    '--format documentation',
   \ 'suite':   '--tag ~slow',
+\}
+let test#rust#cargotest#test_options = {
+  \ 'nearest': ['--', '--nocapture'],
+  \ 'file':    '',
 \}
 ```
 

--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -51,20 +51,28 @@ function! test#rust#cargotest#build_position(type, position) abort
         let l:package = []
     endif
 
-		let l:test_options = g:test#rust#cargotest#test_options
-		if type(g:test#rust#cargotest#test_options) == 1 " string
-			let l:test_options = [g:test#rust#cargotest#test_options]
-		endif
+    let l:test_options = g:test#rust#cargotest#test_options
+    if type(g:test#rust#cargotest#test_options) == 1 " string
+      let l:test_options = [g:test#rust#cargotest#test_options]
+    endif
     if a:type ==# 'nearest'
       let l:test_name = s:nearest_test(a:position)
-			if type(g:test#rust#cargotest#test_options) == 4 " dict
-				let l:test_options = g:test#rust#cargotest#test_options.nearest
-			endif
+      if type(g:test#rust#cargotest#test_options) == 4 " dict
+        let l:test_options = has_key(g:test#rust#cargotest#test_options, 'nearest') ?
+                              \ g:test#rust#cargotest#test_options.nearest : ['--', '--exact']
+        if type(l:test_options) == 1 " string
+          let l:test_options = [l:test_options]
+        endif
+      endif
       return l:package + [shellescape(l:namespace.l:test_name)] + l:test_options
     elseif a:type ==# 'file'
-			if type(g:test#rust#cargotest#test_options) == 4 " dict
-				let l:test_options = g:test#rust#cargotest#test_options.file
-			endif
+      if type(g:test#rust#cargotest#test_options) == 4 " dict
+        let l:test_options = has_key(g:test#rust#cargotest#test_options, 'file') ?
+                             \ g:test#rust#cargotest#test_options.file : []
+        if type(l:test_options) == 1 " string
+          let l:test_options = [l:test_options]
+        endif
+      endif
       " FIXME Should not run submodule tests
       return l:package + [shellescape(l:namespace)] + l:test_options
     endif

--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -16,6 +16,13 @@ if !exists('g:test#rust#cargotest#patterns')
     \ }
 endif
 
+if !exists('g:test#rust#cargotest#test_options')
+  let g:test#rust#cargotest#test_options = {
+        \ 'nearest': ['--', '--exact'],
+        \ 'file': []
+    \ }
+endif
+
 function! test#rust#cargotest#test_file(file) abort
   if a:file =~# g:test#rust#cargotest#file_pattern
     if exists('g:test#rust#runner')
@@ -44,12 +51,22 @@ function! test#rust#cargotest#build_position(type, position) abort
         let l:package = []
     endif
 
+		let l:test_options = g:test#rust#cargotest#test_options
+		if type(g:test#rust#cargotest#test_options) == 1 " string
+			let l:test_options = [g:test#rust#cargotest#test_options]
+		endif
     if a:type ==# 'nearest'
       let l:test_name = s:nearest_test(a:position)
-      return l:package + [shellescape(l:namespace.l:test_name), "--", "--exact"]
+			if type(g:test#rust#cargotest#test_options) == 4 " dict
+				let l:test_options = g:test#rust#cargotest#test_options.nearest
+			endif
+      return l:package + [shellescape(l:namespace.l:test_name)] + l:test_options
     elseif a:type ==# 'file'
+			if type(g:test#rust#cargotest#test_options) == 4 " dict
+				let l:test_options = g:test#rust#cargotest#test_options.file
+			endif
       " FIXME Should not run submodule tests
-      return l:package + [shellescape(l:namespace)]
+      return l:package + [shellescape(l:namespace)] + l:test_options
     endif
   endif
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -617,6 +617,7 @@ You may find yourself specifying certain options for your test runners in
 certain situations. You can configure your preferred options with
 >
   let g:test#ruby#minitest#options = '--verbose'
+  let g:test#rust#cargotest#test_options = '-- --nocapture'
 <
 Or, if you prefer more granular approach, you can do
 >
@@ -624,6 +625,10 @@ Or, if you prefer more granular approach, you can do
     \ 'nearest': '--format documentation',
     \ 'file':    '--format documentation',
     \ 'suite':   '--tag ~slow',
+  \}
+  let test#rust#cargotest#test_options = {
+    \ 'nearest': ['--', '--nocapture', '--exact'],
+    \ 'file':    [],
   \}
 <
 You can also specify a global option for the test runner to work alongside the

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -222,7 +222,7 @@ describe "Cargo"
     view crate/src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
-		cd -
+    cd -
 
     unlet g:test#rust#cargotest#test_options
   end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -159,7 +159,7 @@ describe "Cargo"
     cd -
   end
 
-  it "run with cargotest#test_options"
+  it "run with cargotest test_options"
     let g:test#rust#cargotest#test_options = '-- --nocapture'
 
     view src/main.rs
@@ -218,9 +218,11 @@ describe "Cargo"
 
     let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
 
+    cd ..
     view crate/src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
+		cd -
 
     unlet g:test#rust#cargotest#test_options
   end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -32,16 +32,6 @@ describe "Cargo"
     view src/too/nested.rs
     TestFile
     Expect g:test#last_command == 'cargo test ''too::nested::'''
-		
-		let g:test#rust#cargotest#test_options = '-- --nocapture'
-    
-		view src/main.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test '''' -- --nocapture'
-    
-		view src/too/nested.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test ''too::nested::'' -- --nocapture'
   end
 
   it "runs nearest test on lib.rs"
@@ -56,16 +46,6 @@ describe "Cargo"
     view +7 src/lib.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --exact'
-		
-		let g:test#rust#cargotest#test_options = ['--', '--nocapture --exact']
-    
-		view +7 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
-    
-		view +5 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
   end
 
 
@@ -81,16 +61,6 @@ describe "Cargo"
     view +7 src/somemod_test.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --exact'
-		
-		let g:test#rust#cargotest#test_options = {'nearest': ['--', '--nocapture --exact']}
-    
-		view +7 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
-    
-		view +13 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
   end
 
   it "runs nearest test without mod"
@@ -105,16 +75,6 @@ describe "Cargo"
     view +6 src/nomod.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --exact'
-		
-		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact'}
-    
-		view +6 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
-    
-		view +2 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
   end
 
   it "runs nearest test on modules"
@@ -153,12 +113,6 @@ describe "Cargo"
     view +7 src/too/nested.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --exact'
-		
-		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': []}
-    
-		view +7 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
   end
 
   it "runs test suites"
@@ -177,23 +131,12 @@ describe "Cargo"
     view src/too/nested.rs
     TestSuite
     Expect g:test#last_command == 'cargo test'
-
-		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
-    
-		view src/too/nested.rs
-    TestSuite
-    Expect g:test#last_command == 'cargo test'
   end
 
   it "supports async tokio tests"
     view +15 src/lib.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --exact'
-		
-		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
-    view +15 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
   end
 
   it "supports async actix rt tests"
@@ -213,12 +156,72 @@ describe "Cargo"
     view crate/src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''''
-		
-		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
-    
-		view crate/src/lib.rs
+    cd -
+  end
+
+  it "run with cargotest#test_options"
+    let g:test#rust#cargotest#test_options = '-- --nocapture'
+
+    view src/main.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test '''' -- --nocapture'
+
+    view src/too/nested.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test ''too::nested::'' -- --nocapture'
+
+    let g:test#rust#cargotest#test_options = ['--', '--nocapture --exact']
+
+    view +7 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
+
+    let g:test#rust#cargotest#test_options = {'nearest': ['--', '--nocapture --exact']}
+
+    view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
+
+    view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
+
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact'}
+
+    view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
+
+    view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
+
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': []}
+
+    view +7 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
+
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+
+    view src/too/nested.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
+
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+
+    view crate/src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
-    cd -
+
+    unlet g:test#rust#cargotest#test_options
   end
 end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -151,14 +151,6 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --exact'
   end
 
-  it "runs file tests in workspaces"
-    cd ..
-    view crate/src/lib.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test --package crate '''''
-    cd -
-  end
-
   it "run with cargotest test_options"
     let g:test#rust#cargotest#test_options = '-- --nocapture'
 
@@ -216,14 +208,21 @@ describe "Cargo"
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
 
-    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    unlet g:test#rust#cargotest#test_options
+  end
 
+  it "runs file tests in workspaces"
     cd ..
     view crate/src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
-    cd -
+    Expect g:test#last_command == 'cargo test --package crate '''''
 
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    view crate/src/lib.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
     unlet g:test#rust#cargotest#test_options
+    cd -
   end
+
 end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -212,6 +212,7 @@ describe "Cargo"
   end
 
   it "runs file tests in workspaces"
+    let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ''}
     cd ..
     view crate/src/lib.rs
     TestFile

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -157,4 +157,394 @@ describe "Cargo"
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''''
     cd -
+  end
+end
+
+describe "Cargo with string test_options"
+
+  before
+    let g:test#rust#runner = 'cargotest'
+		let g:test#rust#cargotest#test_options = '-- --nocapture --exact'
+    cd spec/fixtures/cargo/crate
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest test on lib.rs"
+    view +5 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
+  end
+
+
+  it "runs nearest test on modules with mod as test"
+    view +5 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test without mod"
+    view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
+
+    view +10 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
+
+    view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test on modules"
+    view +5 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
+  end
+
+  it "supports async tokio tests"
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
+  end
+
+  it "supports async actix rt tests"
+    view +26 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
+  end
+
+  it "supports rstest tests"
+    view +22 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
+  end
+
+end
+
+describe "Cargo with list test_options"
+
+  before
+    let g:test#rust#runner = 'cargotest'
+		let g:test#rust#cargotest#test_options = ['--', '--nocapture', '--exact']
+    cd spec/fixtures/cargo/crate
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs nearest test on lib.rs"
+    view +5 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
+  end
+
+
+  it "runs nearest test on modules with mod as test"
+    view +5 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test without mod"
+    view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
+
+    view +10 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
+
+    view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test on modules"
+    view +5 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
+  end
+
+  it "supports async tokio tests"
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
+  end
+
+  it "supports async actix rt tests"
+    view +26 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
+  end
+
+  it "supports rstest tests"
+    view +22 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
+  end
+
+end
+
+describe "Cargo with dict test_options"
+
+  before
+    let g:test#rust#runner = 'cargotest'
+		let g:test#rust#cargotest#test_options = {'nearest': ['--', '--nocapture', '--exact'], 'file': [], 'suite': ''}
+    cd spec/fixtures/cargo/crate
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view src/lib.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test '''''
+
+    view src/main.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test '''''
+
+    view src/somemod.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test ''somemod::'''
+
+    view src/nested/mod.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test ''nested::'''
+
+    view src/too/nested.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test ''too::nested::'''
+  end
+
+  it "runs nearest test on lib.rs"
+    view +5 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
+  end
+
+
+  it "runs nearest test on modules with mod as test"
+    view +5 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test without mod"
+    view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
+
+    view +10 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
+
+    view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs nearest test on modules"
+    view +5 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/nested/mod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
+
+    view +5 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
+
+    view +13 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
+
+    view +7 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
+  end
+
+  it "runs test suites"
+    view src/lib.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/somemod.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/nested/mod.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/too/nested.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+  end
+
+  it "supports async tokio tests"
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
+  end
+
+  it "supports async actix rt tests"
+    view +26 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
+  end
+
+  it "supports rstest tests"
+    view +22 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
+  end
+
+  it "runs file tests in workspaces"
+    cd ..
+    view crate/src/lib.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test --package crate '''''
+    cd -
+  end
 end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -32,6 +32,16 @@ describe "Cargo"
     view src/too/nested.rs
     TestFile
     Expect g:test#last_command == 'cargo test ''too::nested::'''
+		
+		let g:test#rust#cargotest#test_options = '-- --nocapture'
+    
+		view src/main.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test '''' -- --nocapture'
+    
+		view src/too/nested.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test ''too::nested::'' -- --nocapture'
   end
 
   it "runs nearest test on lib.rs"
@@ -46,6 +56,16 @@ describe "Cargo"
     view +7 src/lib.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --exact'
+		
+		let g:test#rust#cargotest#test_options = ['--', '--nocapture --exact']
+    
+		view +7 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
+    
+		view +5 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
   end
 
 
@@ -61,6 +81,16 @@ describe "Cargo"
     view +7 src/somemod_test.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --exact'
+		
+		let g:test#rust#cargotest#test_options = {'nearest': ['--', '--nocapture --exact']}
+    
+		view +7 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
+    
+		view +13 src/somemod_test.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
   end
 
   it "runs nearest test without mod"
@@ -75,6 +105,16 @@ describe "Cargo"
     view +6 src/nomod.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --exact'
+		
+		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact'}
+    
+		view +6 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
+    
+		view +2 src/nomod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
   end
 
   it "runs nearest test on modules"
@@ -113,6 +153,12 @@ describe "Cargo"
     view +7 src/too/nested.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --exact'
+		
+		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': []}
+    
+		view +7 src/too/nested.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
   end
 
   it "runs test suites"
@@ -131,12 +177,23 @@ describe "Cargo"
     view src/too/nested.rs
     TestSuite
     Expect g:test#last_command == 'cargo test'
+
+		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    
+		view src/too/nested.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
   end
 
   it "supports async tokio tests"
     view +15 src/lib.rs
     TestNearest
     Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --exact'
+		
+		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    view +15 src/lib.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
   end
 
   it "supports async actix rt tests"
@@ -156,395 +213,12 @@ describe "Cargo"
     view crate/src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test --package crate '''''
-    cd -
-  end
-end
-
-describe "Cargo with string test_options"
-
-  before
-    let g:test#rust#runner = 'cargotest'
-		let g:test#rust#cargotest#test_options = '-- --nocapture --exact'
-    cd spec/fixtures/cargo/crate
-  end
-
-  after
-    call Teardown()
-    cd -
-  end
-
-  it "runs nearest test on lib.rs"
-    view +5 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
-  end
-
-
-  it "runs nearest test on modules with mod as test"
-    view +5 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test without mod"
-    view +2 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
-
-    view +10 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
-
-    view +6 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test on modules"
-    view +5 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
-  end
-
-  it "supports async tokio tests"
-    view +15 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
-  end
-
-  it "supports async actix rt tests"
-    view +26 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
-  end
-
-  it "supports rstest tests"
-    view +22 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
-  end
-
-end
-
-describe "Cargo with list test_options"
-
-  before
-    let g:test#rust#runner = 'cargotest'
-		let g:test#rust#cargotest#test_options = ['--', '--nocapture', '--exact']
-    cd spec/fixtures/cargo/crate
-  end
-
-  after
-    call Teardown()
-    cd -
-  end
-
-  it "runs nearest test on lib.rs"
-    view +5 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
-  end
-
-
-  it "runs nearest test on modules with mod as test"
-    view +5 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test without mod"
-    view +2 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
-
-    view +10 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
-
-    view +6 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test on modules"
-    view +5 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
-  end
-
-  it "supports async tokio tests"
-    view +15 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
-  end
-
-  it "supports async actix rt tests"
-    view +26 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
-  end
-
-  it "supports rstest tests"
-    view +22 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
-  end
-
-end
-
-describe "Cargo with dict test_options"
-
-  before
-    let g:test#rust#runner = 'cargotest'
-		let g:test#rust#cargotest#test_options = {'nearest': ['--', '--nocapture', '--exact'], 'file': [], 'suite': ''}
-    cd spec/fixtures/cargo/crate
-  end
-
-  after
-    call Teardown()
-    cd -
-  end
-
-  it "runs file tests"
-    view src/lib.rs
+		
+		let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
+    
+		view crate/src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo test '''''
-
-    view src/main.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test '''''
-
-    view src/somemod.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test ''somemod::'''
-
-    view src/nested/mod.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test ''nested::'''
-
-    view src/too/nested.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test ''too::nested::'''
-  end
-
-  it "runs nearest test on lib.rs"
-    view +5 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::second_test'' -- --nocapture --exact'
-  end
-
-
-  it "runs nearest test on modules with mod as test"
-    view +5 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod_test.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod_test::test::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test without mod"
-    view +2 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::first_test'' -- --nocapture --exact'
-
-    view +10 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::third_test'' -- --nocapture --exact'
-
-    view +6 src/nomod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nomod::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs nearest test on modules"
-    view +5 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/somemod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''somemod::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/nested/mod.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''nested::tests::second_test'' -- --nocapture --exact'
-
-    view +5 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::first_test'' -- --nocapture --exact'
-
-    view +13 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::third_test'' -- --nocapture --exact'
-
-    view +7 src/too/nested.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --nocapture --exact'
-  end
-
-  it "runs test suites"
-    view src/lib.rs
-    TestSuite
-    Expect g:test#last_command == 'cargo test'
-
-    view src/somemod.rs
-    TestSuite
-    Expect g:test#last_command == 'cargo test'
-
-    view src/nested/mod.rs
-    TestSuite
-    Expect g:test#last_command == 'cargo test'
-
-    view src/too/nested.rs
-    TestSuite
-    Expect g:test#last_command == 'cargo test'
-  end
-
-  it "supports async tokio tests"
-    view +15 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::tokio_async_test'' -- --nocapture --exact'
-  end
-
-  it "supports async actix rt tests"
-    view +26 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::test_actix_rt'' -- --nocapture --exact'
-  end
-
-  it "supports rstest tests"
-    view +22 src/lib.rs
-    TestNearest
-    Expect g:test#last_command == 'cargo test ''tests::rstest_test'' -- --nocapture --exact'
-  end
-
-  it "runs file tests in workspaces"
-    cd ..
-    view crate/src/lib.rs
-    TestFile
-    Expect g:test#last_command == 'cargo test --package crate '''''
+    Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
     cd -
   end
 end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [√] Add fixtures and spec when implementing or updating a test runner
- [√] Update the README accordingly
- [√] Update the Vim documentation in `doc/test.txt`

usage: add to .vimrc
```vim
let test#rust#cargotest#test_options = { 'nearest': ['--', '--nocapture', '--exact'], 'file': [] }
```