### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ function! CustomAlternateFile(cmd)
   return "test_file_spec.rb"
 endfunction
 
-let g:test#custom_alternate_file = function('echo')
+let g:test#custom_alternate_file = function('CustomAlternateFile')
 ```
 
 ## Extending

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -707,7 +707,7 @@ function! CustomAlternateFile(cmd)
   return "test_file_spec.rb"
 endfunction
 
-let g:test#custom_alternate_file = function('echo')
+let g:test#custom_alternate_file = function('CustomAlternateFile')
 <
 
 ABOUT                                           *test-about*


### PR DESCRIPTION
Fixes a typo of mine that was brought up in the original PR - https://github.com/vim-test/vim-test/pull/665

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
