### PR TITLE
feat: add support for root_markers in before_run hook

### DIFF
--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -165,7 +165,25 @@ function! s:alternate_file() abort
   return alternate_file
 endfunction
 
+
 function! s:before_run() abort
+  if !exists('g:test#project_root')
+    let root_markers = get(g:, 'test#root_markers')
+
+    for marker in root_markers
+        let marker_file = findfile(marker, expand('%:p:h') . ';')
+        if strlen(marker_file) > 0
+            let g:test#project_root = fnamemodify(marker_file, ":p:h")
+            break
+        endif
+        let marker_dir = finddir(marker, expand('%:p:h') . ';')
+        if strlen(marker_dir) > 0
+            let g:test#project_root = fnamemodify(marker_dir, ":p:h")
+            break
+        endif
+    endfor
+  endif
+
   if &autowrite || &autowriteall
     silent! wall
   endif


### PR DESCRIPTION
Draft fix to close #272. Unsure if this type of implementation would be supported. Would like some feedback before cleaning up the PR. 

Introduces a `'test#root_markers'` variable that could be set to provide a directory marker.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
