### PR TITLE
bugfix(csharp) - fixing default slash for windows

### DIFF
--- a/autoload/test/csharp.vim
+++ b/autoload/test/csharp.vim
@@ -3,13 +3,13 @@ let g:test#csharp#patterns = {
   \ 'namespace': ['\v^\s*public class (\w+)', '\v^\s*namespace ((\w|\.)+)'],
 \}
 
+" Set the default slash to the forward slash
+let s:slash = '/'
 if (has('win32') || has('win64'))
     let shell = fnamemodify(&shell, ':t')
     if (shell ==? 'cmd.exe' || shell ==? 'powershell')
         let s:slash = '\'
     endif
-else
-    let s:slash = '/'
 endif
 
 function! test#csharp#get_project_path(file) abort


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

When running one of these commands for csharp in windows it was complaining that s:slash variable was not set - I think it might be because I am on windows and not using a terminal that equates to either cmd.exe or powershell, in this case the pack was not working so I have set the slash to be a forward slash unless you are running a specific terminal on windows

Fixes - https://github.com/vim-test/vim-test/issues/731 