### PR TITLE
Only use Sail when it's configured

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -51,7 +51,7 @@ endfunction
 function! test#php#phpunit#executable() abort
   if exists('g:test#php#phpunit#executable')
     return g:test#php#phpunit#executable
-  elseif filereadable('./vendor/bin/sail')
+  elseif filereadable('./vendor/bin/sail') && (filereadable('./docker-compose.yml') || filereadable('./docker-compose.yaml'))
     return './vendor/bin/sail test'
   elseif filereadable('./vendor/bin/paratest')
     return './vendor/bin/paratest'

--- a/spec/sail_spec.vim
+++ b/spec/sail_spec.vim
@@ -6,6 +6,7 @@ describe "Laravel Sail"
     cd spec/fixtures/phpunit
     !mkdir -p vendor/bin
     !touch vendor/bin/sail
+    !touch docker-compose.yml
   end
 
   after
@@ -87,6 +88,14 @@ describe "Laravel Sail"
     TestFile
 
     Expect exists('g:test#last_command') == 0
+  end
+
+  it "doesn't use sail when the docker compose config is missing"
+    !rm docker-compose.yml
+    view NormalTest.php
+    TestFile
+
+    Expect g:test#last_command == 'phpunit --colors NormalTest.php'
   end
 
 end


### PR DESCRIPTION
The current behaviour in vim-test is to use Laravel Sail whenever `vendor/bin/sail` exists, however, this comes pre-installed in fresh Laravel applications these days and does not mean the user will actually be using Docker for local development.

Currently users will get the following error when using vim-test in a fresh Laravel application:
![image](https://github.com/vim-test/vim-test/assets/4977161/7ac0cf37-7a6c-4452-b4da-861b2852685b)

Users that wish to use Sail would typically run `php artisan sail:install` which will create their `docker-compose.yml` file.

This PR updates vim-test to only use Sail when `docker-compose.yml` (or `docker-compose.yaml`) also exists in addition to `vendor/bin/sail`.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`