### PR TITLE
Add Zig Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ runners are supported:
 |      **Shell** | Bats, ShellSpec                                                                                                    | `bats`, `shellspec`                                                                                                                          |
 |      **Swift** | Swift Package Manager                                                                                              | `swiftpm`                                                                                                                                    |
 |  **VimScript** | Vader.vim, Vroom, VSpec, Themis, Testify                                                                           | `vader`, `vroom`, `vspec`, `themis`, `testify`                                                                                               |
+|        **Zig** | ZigTest                                                                                                            | `zigtest`                                                                                                                                    |
 
 ## Setup
 

--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -2,30 +2,15 @@ if !exists('g:test#zig#zigtest#file_pattern')
   let g:test#zig#zigtest#file_pattern = '\v\.zig$'
 endif
 
-if !exists('g:test#zig#zigtest#test_patterns')
-  let g:test#zig#zigtest#test_patterns = {
-        \ 'test': [
-        \ '\vtest "=([^"]*)"= \{',
-        \ ],
-        \ 'namespace': []
-        \ }
-endif
-
-" Returns true if the given file belongs to your test runner
 function! test#zig#zigtest#test_file(file) abort
   return a:file =~# g:test#zig#zigtest#file_pattern
 endfunction
 
-" Returns test runner's arguments which will run the current file and/or line
 function! test#zig#zigtest#build_position(type, position) abort
   if a:type ==# 'nearest'
-    let name = test#base#nearest_test(a:position, g:test#zig#zigtest#test_patterns)
-
-    if empty(name['test'])
-      return []
-    else
-      return ['test', a:position['file'], '--test-filter', ''''.name['test'][0].'''']
-    endif
+    " --test-filter currently only supports filtering string inclusion, so
+    "  multiple tests could match, so instead we run the whole file.
+    return ['test', a:position['file']]
   elseif a:type ==# 'file'
     return ['test', a:position['file']]
   else
@@ -33,7 +18,6 @@ function! test#zig#zigtest#build_position(type, position) abort
   endif
 endfunction
 
-" Returns processed args (if you need to do any processing)
 function! test#zig#zigtest#build_args(args)
   if empty(filter(copy(a:args), 'test#base#file_exists(v:val)'))
     call add(a:args, 'build test')
@@ -42,7 +26,6 @@ function! test#zig#zigtest#build_args(args)
   return a:args
 endfunction
 
-" Returns the executable of your test runner
 function! test#zig#zigtest#executable() abort
   return 'zig'
 endfunction

--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -1,0 +1,48 @@
+if !exists('g:test#zig#zigtest#file_pattern')
+  let g:test#zig#zigtest#file_pattern = '\v\.zig$'
+endif
+
+if !exists('g:test#zig#zigtest#test_patterns')
+  let g:test#zig#zigtest#test_patterns = {
+        \ 'test': [
+        \ '\vtest "=([^"]*)"= \{',
+        \ ],
+        \ 'namespace': []
+        \ }
+endif
+
+" Returns true if the given file belongs to your test runner
+function! test#zig#zigtest#test_file(file) abort
+  return a:file =~# g:test#zig#zigtest#file_pattern
+endfunction
+
+" Returns test runner's arguments which will run the current file and/or line
+function! test#zig#zigtest#build_position(type, position) abort
+  if a:type ==# 'nearest'
+    let name = test#base#nearest_test(a:position, g:test#zig#zigtest#test_patterns)
+
+    if empty(name['test'])
+      return []
+    else
+      return ['test', a:position['file'], '--test-filter', ''''.name['test'][0].'''']
+    endif
+  elseif a:type ==# 'file'
+    return ['test', a:position['file']]
+  else
+    return []
+  endif
+endfunction
+
+" Returns processed args (if you need to do any processing)
+function! test#zig#zigtest#build_args(args)
+  if empty(filter(copy(a:args), 'test#base#file_exists(v:val)'))
+    call add(a:args, 'build test')
+  endif
+
+  return a:args
+endfunction
+
+" Returns the executable of your test runner
+function! test#zig#zigtest#executable() abort
+  return 'zig'
+endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -220,6 +220,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:Bats*
 :Bats [args]                 Uses the `bats` command.
 
+                                                *test-:ZigTest*
+:ZigTest [args]              Uses the `zig` `test` command.
+
                                                 *test-:ShellSpec*
 :ShellSpec [args]                 Uses the `shellspec` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -33,6 +33,7 @@ let g:test#default_runners = {
   \ 'Shell':      ['Bats', 'ShellSpec'],
   \ 'Swift':      ['SwiftPM'],
   \ 'VimL':       ['Themis', 'VSpec', 'Vader', 'Testify', 'Vroom'],
+  \ 'Zig':        ['ZigTest'],
 \}
 
 let g:test#custom_strategies = get(g:, 'test#custom_strategies', {})

--- a/spec/fixtures/zig/normal.zig
+++ b/spec/fixtures/zig/normal.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const testing = std.testing;
+
+test "numbers" {
+    try testing.expect(1 == 1);
+}
+
+test "numbers 2" {
+    try testing.expect(1 == 1);
+}
+
+test addOne {
+    try testing.expect(addOne(1) == 2);
+}
+
+fn addOne(number: i32) i32 {
+    return number + 1;
+}

--- a/spec/zig_spec.vim
+++ b/spec/zig_spec.vim
@@ -22,17 +22,7 @@ describe "Zig"
     view +5 normal.zig
     TestNearest
 
-    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers'''
-
-    view +9 normal.zig
-    TestNearest
-
-    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers 2'''
-
-    view +13 normal.zig
-    TestNearest
-
-    Expect g:test#last_command == 'zig test normal.zig --test-filter ''addOne'''
+    Expect g:test#last_command == 'zig test normal.zig'
   end
 
   it "runs all tests"

--- a/spec/zig_spec.vim
+++ b/spec/zig_spec.vim
@@ -1,0 +1,44 @@
+source spec/support/helpers.vim
+
+describe "Zig"
+
+  before
+    cd spec/fixtures/zig
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view normal.zig
+    TestFile
+
+    Expect g:test#last_command == "zig test normal.zig"
+  end
+
+  it "runs nearest test"
+    view +5 normal.zig
+    TestNearest
+
+    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers'''
+
+    view +9 normal.zig
+    TestNearest
+
+    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers 2'''
+
+    view +13 normal.zig
+    TestNearest
+
+    Expect g:test#last_command == 'zig test normal.zig --test-filter ''addOne'''
+  end
+
+  it "runs all tests"
+    view normal.zig
+    TestSuite
+
+    Expect g:test#last_command == "zig build test"
+  end
+end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

I'm new to both vimscript and zig, so I mostly copied this from the `bats` implementation. From what I can gather, [there isn't a way to use a pattern to run a single test with `zig test`, so there's a chance multiple tests match](https://github.com/ziglang/zig/issues/13524), but this seems close enough for now?

For running the whole suite, seems like there's a pattern to define a test step in `build.zig`, [(1)](https://github.com/mattnite/gyro), [(2)](https://github.com/kooparse/zalgebra), so that's how I decided to implement `TestSuite`.

Either way, thanks for considering! Let me know if I can make any changes.