### PR TITLE
feat: remove logic for setting the no coverage option on Jest tests

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -18,9 +18,9 @@ function! test#javascript#jest#build_position(type, position) abort
     if !empty(name)
       let name = '-t '.shellescape(name, 1)
     endif
-    return ['--no-coverage', '--runTestsByPath', name, '--', a:position['file']]
+    return ['--runTestsByPath', name, '--', a:position['file']]
   elseif a:type ==# 'file'
-    return ['--no-coverage', '--runTestsByPath', '--', a:position['file']]
+    return ['--runTestsByPath', '--', a:position['file']]
   else
     return []
   endif

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -16,85 +16,85 @@ describe "Jest"
       view +1 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math'' -- __tests__/normal-test.js'
 
       view +2 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.js'
 
       view +3 __tests__/normal-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.js'
     end
 
     it "runs loop tests"
       view +1 __tests__/loop-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''Loop the test with given array$'' -- __tests__/loop-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''Loop the test with given array$'' -- __tests__/loop-test.js'
 
       view +2 __tests__/loop-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''loop each tests$'' -- __tests__/loop-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''loop each tests$'' -- __tests__/loop-test.js'
 
       view +3 __tests__/loop-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''described loop test$'' -- __tests__/loop-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''described loop test$'' -- __tests__/loop-test.js'
     end
 
     it "aliases context to describe"
       view +1 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math'' -- __tests__/context-test.js'
 
       view +2 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition'' -- __tests__/context-test.js'
 
       view +3 __tests__/context-test.js
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/context-test.js'
     end
 
     it "runs CoffeeScript"
       view +1 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math'' -- __tests__/normal-test.coffee'
 
       view +2 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.coffee'
 
       view +3 __tests__/normal-test.coffee
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.coffee'
     end
 
     it "runs React"
       view +1 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math'' -- __tests__/normal-test.jsx'
 
       view +2 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition'' -- __tests__/normal-test.jsx'
 
       view +3 __tests__/normal-test.jsx
       TestNearest
 
-      Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
+      Expect g:test#last_command == 'jest --runTestsByPath -t ''^Math Addition adds two numbers$'' -- __tests__/normal-test.jsx'
     end
   end
 
@@ -103,14 +103,14 @@ describe "Jest"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest --runTestsByPath -- __tests__/normal-test.js'
   end
 
   it "runs file tests"
     view __tests__/normal-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest --runTestsByPath -- __tests__/normal-test.js'
   end
 
   it "runs test suites"
@@ -124,7 +124,7 @@ describe "Jest"
     view outside-test.js
     TestFile
 
-    Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -- outside-test.js'
+    Expect g:test#last_command == 'jest --runTestsByPath -- outside-test.js'
   end
 
   context "with a specified executable"
@@ -137,7 +137,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'npm run jest --no-coverage --runTestsByPath -- __tests__/normal-test.js'
+      Expect g:test#last_command == 'npm run jest --runTestsByPath -- __tests__/normal-test.js'
     end
 
     it "runs tests against yarn executable (without --)"
@@ -145,7 +145,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == 'yarn jest --no-coverage --runTestsByPath __tests__/normal-test.js'
+      Expect g:test#last_command == 'yarn jest --runTestsByPath __tests__/normal-test.js'
     end
 
     it "runs tests against absolute path yarn executable (without --)"
@@ -153,7 +153,7 @@ describe "Jest"
       view __tests__/normal-test.js
       TestFile
 
-      Expect g:test#last_command == '~/.local/bin/yarn jest --no-coverage --runTestsByPath __tests__/normal-test.js'
+      Expect g:test#last_command == '~/.local/bin/yarn jest --runTestsByPath __tests__/normal-test.js'
     end
   end
 

--- a/spec/specify_js_runner_spec.vim
+++ b/spec/specify_js_runner_spec.vim
@@ -20,7 +20,7 @@ describe "Multiple JavaScript runners"
     normal O
     TestNearest
 
-    Expect g:test#last_command == 'jest --no-coverage --runTestsByPath -- __tests__/normal-test.js'
+    Expect g:test#last_command == 'jest --runTestsByPath -- __tests__/normal-test.js'
     unlet g:test#javascript#runner
   end
 


### PR DESCRIPTION
This resolves #745 by removing the logic for setting the no coverage option on Jest tests

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
