### PR TITLE
Enable AVA.js test detection in typescript files

### DIFF
--- a/autoload/test/javascript/ava.vim
+++ b/autoload/test/javascript/ava.vim
@@ -1,5 +1,5 @@
 if !exists('g:test#javascript#ava#file_pattern')
-  let g:test#javascript#ava#file_pattern = '\vtests?/.*\.(js|jsx|coffee)$'
+  let g:test#javascript#ava#file_pattern = '\vtests?/.*\.(js|jsx|ts|tsx|coffee)$'
 endif
 
 function! test#javascript#ava#test_file(file) abort

--- a/spec/ava_spec.vim
+++ b/spec/ava_spec.vim
@@ -12,52 +12,107 @@ describe "Ava"
     cd -
   end
 
-  it "runs nearest test"
-    view +1 test/normal.js
-    TestNearest
+  describe "Javascript"
 
-    Expect g:test#last_command == 'ava test/normal.js --match=''Adds two numbers'''
-  end
+    it "runs nearest test"
+      view +1 test/normal.js
+      TestNearest
 
-  it "runs file test if nearest test couldn't be found"
-    view +1 test/normal.js
-    normal O
-    TestNearest
+      Expect g:test#last_command == 'ava test/normal.js --match=''Adds two numbers'''
+    end
 
-    Expect g:test#last_command == 'ava test/normal.js'
-  end
+    it "runs file test if nearest test couldn't be found"
+      view +1 test/normal.js
+      normal O
+      TestNearest
 
-  it "runs file tests"
-    view test/normal.js
-    TestFile
+      Expect g:test#last_command == 'ava test/normal.js'
+    end
 
-    Expect g:test#last_command == 'ava test/normal.js'
-  end
-
-  it "runs test suites"
-    view test/normal.js
-    TestSuite
-
-    Expect g:test#last_command == 'ava'
-  end
-
-  it "also recognizes tests/ directory"
-    try
-      !mv test tests
-      view tests/normal.js
+    it "runs file tests"
+      view test/normal.js
       TestFile
 
-      Expect g:test#last_command == 'ava tests/normal.js'
-    finally
-      !mv tests test
-    endtry
+      Expect g:test#last_command == 'ava test/normal.js'
+    end
+
+    it "runs test suites"
+      view test/normal.js
+      TestSuite
+
+      Expect g:test#last_command == 'ava'
+    end
+
+    it "also recognizes tests/ directory"
+      try
+        !mv test tests
+        view tests/normal.js
+        TestFile
+
+        Expect g:test#last_command == 'ava tests/normal.js'
+      finally
+        !mv tests test
+      endtry
+    end
+
+    it "doesn't detect JavaScripts which are not in the test/ folder"
+      view outside.js
+      TestSuite
+
+      Expect exists('g:test#last_command') == 0
+    end
+
   end
 
-  it "doesn't detect JavaScripts which are not in the test/ folder"
-    view outside.js
-    TestSuite
+  describe "Typescript"
 
-    Expect exists('g:test#last_command') == 0
+    it "runs nearest test"
+      view +1 test/normal.ts
+      TestNearest
+
+      Expect g:test#last_command == 'ava test/normal.ts --match=''Adds two numbers: TS'''
+    end
+
+    it "runs file test if nearest test couldn't be found"
+      view +1 test/normal.ts
+      normal O
+      TestNearest
+
+      Expect g:test#last_command == 'ava test/normal.ts'
+    end
+
+    it "runs file tests"
+      view test/normal.ts
+      TestFile
+
+      Expect g:test#last_command == 'ava test/normal.ts'
+    end
+
+    it "runs test suites"
+      view test/normal.ts
+      TestSuite
+
+      Expect g:test#last_command == 'ava'
+    end
+
+    it "also recognizes tests/ directory"
+      try
+        !mv test tests
+        view tests/normal.ts
+        TestFile
+
+        Expect g:test#last_command == 'ava tests/normal.ts'
+      finally
+        !mv tests test
+      endtry
+    end
+
+    it "doesn't detect JavaScripts which are not in the test/ folder"
+      view outside.js
+      TestSuite
+
+      Expect exists('g:test#last_command') == 0
+    end
   end
 
 end

--- a/spec/ava_spec.vim
+++ b/spec/ava_spec.vim
@@ -12,107 +12,66 @@ describe "Ava"
     cd -
   end
 
-  describe "Javascript"
+  it "runs nearest test"
+    view +1 test/normal.js
+    TestNearest
 
-    it "runs nearest test"
-      view +1 test/normal.js
-      TestNearest
-
-      Expect g:test#last_command == 'ava test/normal.js --match=''Adds two numbers'''
-    end
-
-    it "runs file test if nearest test couldn't be found"
-      view +1 test/normal.js
-      normal O
-      TestNearest
-
-      Expect g:test#last_command == 'ava test/normal.js'
-    end
-
-    it "runs file tests"
-      view test/normal.js
-      TestFile
-
-      Expect g:test#last_command == 'ava test/normal.js'
-    end
-
-    it "runs test suites"
-      view test/normal.js
-      TestSuite
-
-      Expect g:test#last_command == 'ava'
-    end
-
-    it "also recognizes tests/ directory"
-      try
-        !mv test tests
-        view tests/normal.js
-        TestFile
-
-        Expect g:test#last_command == 'ava tests/normal.js'
-      finally
-        !mv tests test
-      endtry
-    end
-
-    it "doesn't detect JavaScripts which are not in the test/ folder"
-      view outside.js
-      TestSuite
-
-      Expect exists('g:test#last_command') == 0
-    end
-
+    Expect g:test#last_command == 'ava test/normal.js --match=''Adds two numbers'''
   end
 
-  describe "Typescript"
+  it "runs file test if nearest test couldn't be found"
+    view +1 test/normal.js
+    normal O
+    TestNearest
 
-    it "runs nearest test"
-      view +1 test/normal.ts
-      TestNearest
+    Expect g:test#last_command == 'ava test/normal.js'
+  end
 
-      Expect g:test#last_command == 'ava test/normal.ts --match=''Adds two numbers: TS'''
-    end
+  it "runs file tests"
+    view test/normal.js
+    TestFile
 
-    it "runs file test if nearest test couldn't be found"
-      view +1 test/normal.ts
-      normal O
-      TestNearest
+    Expect g:test#last_command == 'ava test/normal.js'
+  end
 
-      Expect g:test#last_command == 'ava test/normal.ts'
-    end
+  it "runs test suites"
+    view test/normal.js
+    TestSuite
 
-    it "runs file tests"
-      view test/normal.ts
+    Expect g:test#last_command == 'ava'
+  end
+
+  it "also recognizes tests/ directory"
+    try
+      !mv test tests
+      view tests/normal.js
       TestFile
 
-      Expect g:test#last_command == 'ava test/normal.ts'
-    end
+      Expect g:test#last_command == 'ava tests/normal.js'
+    finally
+      !mv tests test
+    endtry
+  end
 
-    it "runs test suites"
-      view test/normal.ts
-      TestSuite
+  it "doesn't detect JavaScripts which are not in the test/ folder"
+    view outside.js
+    TestSuite
 
-      Expect g:test#last_command == 'ava'
-    end
+    Expect exists('g:test#last_command') == 0
+  end
 
-    it "also recognizes tests/ directory"
-      try
-        !mv test tests
-        view tests/normal.ts
-        TestFile
+  it "runs nearest tests in typescript test files"
+    view +1 test/normal.ts
+    TestNearest
 
-        Expect g:test#last_command == 'ava tests/normal.ts'
-      finally
-        !mv tests test
-      endtry
-    end
+    Expect g:test#last_command == 'ava test/normal.ts --match=''Adds two numbers: TS'''
+  end
 
-    it "doesn't detect JavaScripts which are not in the test/ folder"
-      view outside.js
-      TestSuite
+  it "runs file tests in typescript test files"
+    view test/normal.ts
+    TestFile
 
-      Expect exists('g:test#last_command') == 0
-    end
+    Expect g:test#last_command == 'ava test/normal.ts'
   end
 
 end

--- a/spec/fixtures/ava/test/normal.ts
+++ b/spec/fixtures/ava/test/normal.ts
@@ -1,0 +1,3 @@
+test('Adds two numbers: TS', t => {
+  // assertions
+});


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [-] Update the README accordingly
- [-] Update the Vim documentation in `doc/test.txt`

## Allow AVA.js users to run tests on their `.test.ts` files.

Brings AVA runner up to parity with Jest and other javascript runners.

It appears to me that the README and test.txt do not go into a level of detail where this change can be documented meaningfully. It is more of a bugfix catching the runner up to what a consumer would ordinarily expect from current documentation.
