### PR TITLE
zig: use --test-filter when running nearest test

### DIFF
--- a/autoload/test/zig.vim
+++ b/autoload/test/zig.vim
@@ -1,0 +1,5 @@
+let test#zig#patterns = {
+  \ 'whole_match': 1,
+  \ 'test': ['\v^\s*test\s(")\zs%(.{-}%(\\\1)?){-}\ze\1'],
+  \ 'namespace': []
+\}

--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -9,12 +9,11 @@ endfunction
 function! test#zig#zigtest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
-    if !empty(name)
-      let filter = '--test-filter '.shellescape(name, 1)
-      return ['test', a:position['file'], filter]
+    if empty(name)
+      return ['test', a:position['file']]
     endif
 
-    return ['test', a:position['file']]
+    return ['test', a:position['file'],  '--test-filter '.shellescape(name, 1)]
   elseif a:type ==# 'file'
     return ['test', a:position['file']]
   else

--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -8,8 +8,12 @@ endfunction
 
 function! test#zig#zigtest#build_position(type, position) abort
   if a:type ==# 'nearest'
-    " --test-filter currently only supports filtering string inclusion, so
-    "  multiple tests could match, so instead we run the whole file.
+    let name = s:nearest_test(a:position)
+    if !empty(name)
+      let filter = '--test-filter '.shellescape(name, 1)
+      return ['test', a:position['file'], filter]
+    endif
+
     return ['test', a:position['file']]
   elseif a:type ==# 'file'
     return ['test', a:position['file']]
@@ -28,4 +32,9 @@ endfunction
 
 function! test#zig#zigtest#executable() abort
   return 'zig'
+endfunction
+
+function! s:nearest_test(position) abort
+  let name = test#base#nearest_test(a:position, g:test#zig#patterns)
+  return test#base#escape_regex(join(name['test']))
 endfunction

--- a/spec/zig_spec.vim
+++ b/spec/zig_spec.vim
@@ -19,10 +19,10 @@ describe "Zig"
   end
 
   it "runs nearest test"
-    view +5 normal.zig
+    view +9 normal.zig
     TestNearest
 
-    Expect g:test#last_command == 'zig test normal.zig'
+    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers 2'''
   end
 
   it "runs all tests"


### PR DESCRIPTION
This changes the 'nearest' test type to use `zig test --test-filter`. It kinda goes against the decision made by @bobcats  in https://github.com/vim-test/vim-test/pull/736, which specifically didn't support this because `--test-filter` doesn't allow for regexs and might run more tests than we want.

But I figured: I'd rather run more tests if they match the same name, vs. the whole file all the time.

At least I want this feature, but happy to hear any feedback :)

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
