### PR TITLE
Obey g:test#preserve_screen for 'shtuff' strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -170,7 +170,11 @@ function! test#strategy#shtuff(cmd) abort
     return
   endif
 
-  call system("shtuff into " . shellescape(g:shtuff_receiver) . " " . shellescape("clear;" . a:cmd))
+  if exists('g:test#preserve_screen') && !g:test#preserve_screen
+      call system("shtuff into " . shellescape(g:shtuff_receiver) . " " . shellescape("clear;" . a:cmd))
+  else
+      call system("shtuff into " . shellescape(g:shtuff_receiver) . " " . shellescape(a:cmd))
+  endif
 endfunction
 
 function! test#strategy#harpoon(cmd) abort


### PR DESCRIPTION
The `shtuff` strategy did not obey the `g:test#preserve_screen` option. No doc or README update because it already implied that it would be obeyed... No fixture or spec related to `shtuff` to update.

Make sure these boxes are checked before submitting your pull request:

- [ ] ~~Add fixtures and spec when implementing or updating a test runner~~
- [ ] ~~Update the README accordingly~~
- [ ] ~~Update the Vim documentation in `doc/test.txt`~~
