### PR TITLE
fix: not recognizing project names when using Nx

### DIFF
--- a/autoload/test/javascript/nx.vim
+++ b/autoload/test/javascript/nx.vim
@@ -14,12 +14,19 @@ endfunction
 
 function! test#javascript#nx#build_position(type, position) abort
   let project = ''
-  if filereadable('workspace.json')
+
+  let l:project_json = findfile('project.json', '.;')
+  if filereadable(project_json)
+    let l:project_json_file = readfile(project_json)
+    if exists('*json_decode')
+      let project = json_decode(join(project_json_file, ''))['name']
+    endif
+  elseif filereadable('workspace.json')
     let l:workpaces = readfile('workspace.json')
     if exists('*json_decode')
       let l:projects = json_decode(join(workpaces, ''))['projects']
       for [key, value] in items(projects)
-        if stridx(a:position['file'], value) >= 0 
+        if stridx(a:position['file'], value) >= 0
           let project = key
           break
         endif
@@ -32,14 +39,13 @@ function! test#javascript#nx#build_position(type, position) abort
     if !empty(name)
       let name = '-t '.shellescape(name, 1)
     endif
-    return [project, name, '--test-file', a:position['file'], '--no-coverage']
+    return [project, name, '--test-file', a:position['file']]
   elseif a:type ==# 'file'
-    return [project, '--test-file', a:position['file'], '--no-coverage']
+    return [project, '--test-file', a:position['file']]
   else
-    return [project, '--no-coverage']
+    return [project]
   endif
 endfunction
-
 
 let s:yarn_command = '\<yarn\>'
 function! test#javascript#nx#build_args(args) abort

--- a/autoload/test/javascript/nx.vim
+++ b/autoload/test/javascript/nx.vim
@@ -13,18 +13,33 @@ function! test#javascript#nx#test_file(file) abort
 endfunction
 
 function! test#javascript#nx#build_position(type, position) abort
+  let project = ''
+  if filereadable('workspace.json')
+    let l:workpaces = readfile('workspace.json')
+    if exists('*json_decode')
+      let l:projects = json_decode(join(workpaces, ''))['projects']
+      for [key, value] in items(projects)
+        if stridx(a:position['file'], value) >= 0 
+          let project = key
+          break
+        endif
+      endfor
+    endif
+  endif
+
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
       let name = '-t '.shellescape(name, 1)
     endif
-    return [name, '--test-file', a:position['file']]
+    return [project, name, '--test-file', a:position['file'], '--no-coverage']
   elseif a:type ==# 'file'
-    return ['--test-file', a:position['file']]
+    return [project, '--test-file', a:position['file'], '--no-coverage']
   else
-    return []
+    return [project, '--no-coverage']
   endif
 endfunction
+
 
 let s:yarn_command = '\<yarn\>'
 function! test#javascript#nx#build_args(args) abort

--- a/spec/fixtures/nx/apps/backend/normal-test.js
+++ b/spec/fixtures/nx/apps/backend/normal-test.js
@@ -1,0 +1,7 @@
+describe('Math', function() {
+  describe('Addition', function() {
+    it('adds two numbers', function() {
+      //assertions
+    });
+  });
+});

--- a/spec/fixtures/nx/apps/backend/project.json
+++ b/spec/fixtures/nx/apps/backend/project.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "sourceRoot": "apps/backend/src",
+  "projectType": "application",
+  "generators": {}
+}

--- a/spec/fixtures/nx/apps/products/normal-test.jsx
+++ b/spec/fixtures/nx/apps/products/normal-test.jsx
@@ -1,0 +1,8 @@
+describe('Math', function() {
+  describe('Addition', function() {
+    it('adds two numbers', function() {
+      // assertions
+    });
+  });
+});
+

--- a/spec/fixtures/nx/workspace.json
+++ b/spec/fixtures/nx/workspace.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "projects": {
+    "products": "apps/products"
+  },
+  "$schema": "./node_modules/nx/schemas/workspace-schema.json"
+}

--- a/spec/nx_spec.vim
+++ b/spec/nx_spec.vim
@@ -81,6 +81,20 @@ describe "Nx"
     end
   end
 
+  it "references the project when project.json is used"
+    view +1 apps/backend/normal-test.js
+    TestNearest
+
+    Expect g:test#last_command == 'nx test backend -t ''^Math'' --test-file apps/backend/normal-test.js'
+  end
+
+  it "references the project when workspace.json is used"
+    view +1 apps/products/normal-test.jsx
+    TestNearest
+
+    Expect g:test#last_command == 'nx test products -t ''^Math'' --test-file apps/products/normal-test.jsx'
+  end
+
   it "runs file test if nearest test couldn't be found"
     view +1 __tests__/normal-test.js
     normal O


### PR DESCRIPTION
As mentioned in #633 and addressed in #649, when running tests in an nx environment it needs to reference the project name, (i.e. `nx test <project-name>`). Since #649 was opened, [`nx` has stopped using the `workspace.json`](https://nx.dev/deprecated/workspace-json#) format to list project names. In newer Nx codebases, project directories have a `project.json`file.

This PR adds implementation to identify a project name from either the `project.json` file or `workspace.json` file as implemented in #649.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
