### PR TITLE
Add Haskell test runner: cabaltest

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ runners are supported:
 |     **Erlang** | CommonTest, EUnit, PropEr                                                                                          | `commontest`, `eunit`, `proper`                                                                                                              |
 |         **Go** | Ginkgo, Go, Rich-Go, Delve                                                                                         | `ginkgo`, `gotest`, `richgo`, `delve`                                                                                                        |
 |     **Groovy** | Maven, Gradle                                                                                                      | `maventest`, `gradletest`                                                                                                                    |
-|    **Haskell** | stack                                                                                                              | `stacktest`                                                                                                                                  |
+|    **Haskell** | stack, cabal                                                                                                       | `stacktest`, `cabaltest`                                                                                                                     |
 |       **Java** | Maven, Gradle (Groovy and Kotlin DSL)                                                                              | `maventest`, `gradletest`                                                                                                                    |
 | **JavaScript** | Ava, Cucumber.js, Cypress, Deno, Ember, Intern, Jasmine, Jest, Karma, Lab, Mocha, ng test, NX, Playwright, ReactScripts, TAP, Teenytest, WebdriverIO | `ava`, `cucumberjs`, `cypress`, `deno`, `ember exam`, `intern`, `jasmine`, `jest`, `karma`, `lab`, `mocha`, `ngtest` , `nx`, `playwright`, `reactscripts`, `tap`, `teenytest`, `webdriverio`, `vue-test-utils`, `vitest`|
 |     **Kotlin** | Gradle (Groovy and Kotlin DSL)                                                                                     | `gradletest`                                                                                                                                 |
@@ -601,7 +601,20 @@ let g:test#javascript#runner = 'jest'
 
 #### Haskell
 
-The `stackTest` runner currently supports running tests in Stack projects with the [HSpec](http://hackage.haskell.org/package/hspec) framework.
+The `stacktest` runner is used by default. You can switch to `cabaltest` like so:
+
+```vim
+let g:test#haskell#runner = 'cabaltest'
+```
+
+You can pass additional arguments to the test runner by setting its `test_command`. Here's an example for cabal:
+
+```vim
+let g:test#haskell#cabaltest#test_command = 'test --test-show-details=direct'
+```
+
+The runners currently supports running tests with the [HSpec](http://hackage.haskell.org/package/hspec) framework.
+
 
 #### PHP
 

--- a/autoload/test/haskell/cabaltest.vim
+++ b/autoload/test/haskell/cabaltest.vim
@@ -81,11 +81,10 @@ endfunction
 
 " Wrapper around text#base#nearest_test returns the first match
 " or an empty string if no match is found
-" and escapes parentheses and quotes
 function! s:get_nearest(position, patterns) abort
   let l:result = test#base#nearest_test(a:position, a:patterns)
   let l:matches = l:result['test'] + ['']
-  return escape(escape(l:matches[0], '"'), "'")
+  return l:matches[0]
 endfunction
 
 " Returns the nearest project directory containing cabal.project.

--- a/autoload/test/haskell/cabaltest.vim
+++ b/autoload/test/haskell/cabaltest.vim
@@ -1,0 +1,119 @@
+if !exists('g:test#haskell#cabaltest#file_pattern')
+  let g:test#haskell#cabaltest#file_pattern = '\v^(.*spec.*)\c\.hs$'
+endif
+
+if !exists('g:test#haskell#cabaltest#test_command')
+  let g:test#haskell#cabaltest#test_command = 'test'
+endif
+
+" Returns true if the given file belongs to your test runner
+function! test#haskell#cabaltest#test_file(file) abort
+  return test#haskell#test_file('cabaltest', g:test#haskell#cabaltest#file_pattern, a:file)
+endfunction
+
+" Returns test runner's arguments which will run the current file and/or line
+function! test#haskell#cabaltest#build_position(type, position) abort
+  let l:filename = fnamemodify(a:position['file'], ':t:r')
+  let l:file_parent_dir = fnamemodify(a:position['file'], ':p:h')
+  let l:package_dir = s:get_nearest_package_dir(l:file_parent_dir)
+  let l:project_dir = s:get_nearest_project_dir(l:file_parent_dir)
+  let l:package_name_arg = ""
+  if strlen(l:package_dir) > 0 && l:package_dir != l:project_dir
+    " Multi-package project
+    let l:package_name_arg = fnamemodify(l:package_dir, ":t")
+  endif
+
+  if a:type ==# 'nearest'
+    let l:name = s:nearest_test(a:position)
+    let l:module_name = s:get_module_name(a:position)
+    if !empty(l:name)
+      return s:mk_test_command(l:package_name_arg, l:name)
+    elseif !empty(l:module_name)
+      return s:mk_test_command(l:package_name_arg, l:module_name)
+    endif
+  elseif a:type ==# 'file'
+    let l:module_name = s:get_module_name(a:position)
+    if !empty(l:module_name)
+      return s:mk_test_command(l:package_name_arg, l:module_name)
+    endif
+  endif
+  return s:mk_test_command(l:package_name_arg, "")
+endfunction
+
+function! test#haskell#cabaltest#build_args(args) abort
+  return a:args
+endfunction
+
+function! test#haskell#cabaltest#executable() abort
+  return 'cabal'
+endfunction
+
+function! s:nearest_test(position) abort
+  return s:get_nearest(a:position, g:test#haskell#patterns)
+endfunction
+
+" Returns the cabal test command with --test-option=--match \"<hspec_match>"\.
+function! s:mk_test_command(package_name_arg, hspec_match) abort
+  let l:test_args = ""
+  if !empty(a:hspec_match)
+    let l:test_args = "--test-option=--match=\"" . a:hspec_match . "\""
+  end
+  return [g:test#haskell#cabaltest#test_command, a:package_name_arg, l:test_args]
+endfunction
+
+" Gets the module name (without "Spec")
+function! s:get_module_name(position) abort
+  let l:first_line_pos = {'col': 1, 'line': 0, 'file': a:position['file']}
+  return s:get_module_name_helper(l:first_line_pos)
+endfunction
+
+" Helper function for get_module_name.
+" Recursively increases the line number until a match is found
+function! s:get_module_name_helper(position) abort
+  let l:next_line_position = {'col': 1, 'line': a:position['line'] + 1, 'file': a:position['file']}
+  let l:module_pattern = {'test': ['\v\s*module\s\zs([^ ()]*)'], 'namespace': []}
+  let l:module_name = s:get_nearest(l:next_line_position, l:module_pattern)
+  if strlen(l:module_name) > 0
+    return substitute(l:module_name, 'Spec', '', '')
+  endif
+  return s:get_module_name_helper(l:next_line_position)
+endfunction
+
+" Wrapper around text#base#nearest_test returns the first match
+" or an empty string if no match is found
+" and escapes parentheses and quotes
+function! s:get_nearest(position, patterns) abort
+  let l:result = test#base#nearest_test(a:position, a:patterns)
+  let l:matches = l:result['test'] + ['']
+  return escape(escape(l:matches[0], '"'), "'")
+endfunction
+
+" Returns the nearest project directory containing cabal.project.
+" Returns 0 if no directory is found.
+function!s:get_nearest_project_dir(pwd) abort
+  return s:get_nearest_parent_dir(a:pwd, "cabal.project")
+endfunction
+
+" Returns the nearest package directory containing *.cabal.
+" Returns 0 if no directory is found.
+function!s:get_nearest_package_dir(pwd) abort
+  return s:get_nearest_parent_dir(a:pwd, "*.cabal")
+endfunction
+
+" Recursively search pwd and its parent directories until file_name is found.
+" Returns the path to the directory containing file_name.
+" Returns 0 if no directory is found.
+function! s:get_nearest_parent_dir(pwd, file_name) abort
+  if a:pwd ==# "\/"
+    return 0
+  else
+    let l:file_path = a:pwd . "/" . a:file_name
+    if filereadable(expand(l:file_path))
+      return a:pwd
+    else
+      let l:parent = fnamemodify(a:pwd, ':h')
+      return s:get_nearest_parent_dir(l:parent, a:file_name)
+    endif
+  endif
+endfunction
+

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -297,6 +297,9 @@ In all commands [args] are forwarded to the underlying test runner.
                                                 *test-:StackTest*
 :StackTest [args]            Uses the `stack test` command.
 
+                                                *test-:CabalTest*
+:CabalTest [args]            Uses the `cabal test` command.
+
                                                 *test-:NgTest*
 :NgTest [args]  	         Uses the Angular `ng test` command.
 

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -16,7 +16,7 @@ let g:test#default_runners = {
   \ 'Erlang':     ['CommonTest', 'EUnit', 'PropEr'],
   \ 'Go':         ['GoTest', 'Ginkgo', 'RichGo', 'Delve'],
   \ 'Groovy':     ['MavenTest', 'GradleTest'],
-  \ 'Haskell':    ['StackTest'],
+  \ 'Haskell':    ['StackTest', 'CabalTest'],
   \ 'Java':       ['MavenTest', 'GradleTest'],
   \ 'JavaScript': ['Ava', 'CucumberJS', 'DenoTest', 'Intern', 'TAP', 'Teenytest', 'Karma', 'Lab', 'Mocha',  'NgTest', 'Nx', 'Jasmine', 'Jest', 'ReactScripts', 'WebdriverIO', 'Cypress', 'VueTestUtils', 'Playwright', 'Vitest', 'Ember'],
   \ 'Kotlin':     ['GradleTest'],

--- a/spec/cabaltest_multipackage_spec.vim
+++ b/spec/cabaltest_multipackage_spec.vim
@@ -1,0 +1,80 @@
+source spec/support/helpers.vim
+
+describe "CABAL (multi-package)"
+
+  before
+    let g:test#haskell#runner = 'cabaltest'
+    cd spec/fixtures/cabal/multi-package
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+
+  it "TestSuite detects correct subpackage (1)"
+    view subpackage1/test/Spec.hs
+    TestSuite
+
+    Expect g:test#last_command == "cabal test subpackage1"
+  end
+
+  it "TestSuite detects correct subpackage (2)"
+    view subpackage2/test/Spec.hs
+    TestSuite
+
+    Expect g:test#last_command == "cabal test subpackage2"
+  end
+
+  it "TestSuite detects correct subpackage in subdirectory"
+    view common/subpackage3/test/Spec.hs
+    TestSuite
+
+    Expect g:test#last_command == "cabal test subpackage3"
+  end
+
+  it "TestFile detects fully qualified module name and correct subpackage (1)"
+    view subpackage1/test/Fix1/FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test subpackage1 --test-option=--match=\"Fix1.Fixture\""
+  end
+
+  it "TestFile detects fully qualified module name and correct subpackage (2)"
+    view subpackage2/test/Fix2/FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test subpackage2 --test-option=--match=\"Fix2.Fixture\""
+  end
+
+  it "TestFile detects fully qualified module name and correct subpackage (in subdirectory)"
+    view common/subpackage3/test/Fix3/FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test subpackage3 --test-option=--match=\"Fix3.Fixture\""
+  end
+
+  it "TestNearest runs nearest 'it' test and detects correct subpackage"
+    view +11 subpackage1/test/Fix1/FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test subpackage1 --test-option=--match=\"returns the first element of a list\""
+  end
+
+  it "TestNearest runs nearest 'prop' test and detects correct subpackage"
+    view +13 subpackage1/test/Fix1/FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test subpackage1 --test-option=--match=\"returns the first element of an *arbitrary* list\""
+  end
+
+  " TODO
+  " it "TestNearest detects nested describes"
+  "   view +17 subpackage1/test/Fix1/FixtureSpec.hs
+  "   TestNearest
+  "
+  "   Expect g:test#last_command == "cabal test subpackage1 --test-option=--match=\"Fix1.Fixture/Prelude.head/Empyt list/throws an exception if used with an empty list\"'"
+  " end
+  
+end

--- a/spec/cabaltest_singlepackage_spec.vim
+++ b/spec/cabaltest_singlepackage_spec.vim
@@ -1,0 +1,104 @@
+source spec/support/helpers.vim
+
+describe "CABAL (single-package)"
+
+  before
+    let g:test#haskell#runner = 'cabaltest'
+    cd spec/fixtures/cabal/single-package
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+
+  it "TestSuite runs all tests"
+    view test/Spec.hs
+    TestSuite
+
+    Expect g:test#last_command == "cabal test"
+  end
+
+  it "TestFile runs all tests in main test module"
+    view test/Spec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test"
+  end
+
+  it "TestNearest runs all tests in main test module"
+    view test/Spec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test"
+  end
+
+  it "TestFile detects fully qualified module name (qualified imports)"
+    view test/Fix/FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"Fix.Fixture\""
+  end
+
+  it "TestNearest runs nearest 'it' (qualified imports)"
+    view +10 test/Fix/FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"returns the first element of a list\""
+  end
+
+  it "TestNearest runs nearest 'prop' test (qualified imports)"
+    view +12 test/Fix/FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"returns the first element of an *arbitrary* list\""
+  end
+
+  " TODO ?
+  " it "TestNearest correctly traverses the describe tree from node to root (qualfied imports)"
+  "   view +19 test/Fix/FixtureSpec.hs
+  "   TestNearest
+  "
+  "   Expect g:test#last_command == "cabal test --test-option=--match=\"/Prelude.head/Empyt list/throws an exception if used with an empty list\""
+  " end
+  
+  it "TestFile detects fully qualified module name (unqualified imports)"
+    view test/Fix/Fixture2Spec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"Fix.Fixture2\""
+  end
+
+  it "TestNearest runs nearest 'it' test (unqualified imports)"
+    view +13 test/Fix/Fixture2Spec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"returns the first element of a list\""
+  end
+
+  it "TestNearest runs nearest 'prop' test (unqualified imports)"
+    view +15 test/Fix/Fixture2Spec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"returns the first element of an *arbitrary* list\""
+  end
+
+  " TODO ?
+  " it "TestNearest correctly traverses the describe tree from node to root (unqualfied imports)"
+  "   view +19 test/Fix/Fixture2Spec.hs
+  "   TestNearest
+  "
+  "   Expect g:test#last_command == "cabal test --test-option=--match=\"/Prelude.head/Empyt list/throws an exception if used with an empty list\""
+  " end
+  "
+  it "TestFile detects fully qualified module name (with language pragmas)"
+    view test/Fix/Fixture3Spec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"Fix.Fixture3\""
+  end
+
+  
+end
+

--- a/spec/cabaltest_spec.vim
+++ b/spec/cabaltest_spec.vim
@@ -1,0 +1,46 @@
+source spec/support/helpers.vim
+
+describe "CABAL"
+
+  before
+    let g:test#haskell#runner = 'cabaltest'
+    cd spec/fixtures/cabal
+  end
+
+  after
+    call Teardown()
+    cd -
+  end
+
+  it "runs when filename matches *Spec.hs"
+    view FixtureSpec.hs
+    TestFile
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"Fixture\""
+  end
+
+  it "runs nearest tests"
+    view +9 FixtureSpec.hs
+    TestNearest
+
+    Expect g:test#last_command == "cabal test --test-option=--match=\"returns the first element of a list\""
+  end
+
+  it "runs all test in a suite"
+    view FixtureSpec.hs
+    TestSuite
+
+    Expect g:test#last_command == 'cabal test'
+  end
+
+  it "allows overriding the test command"
+    let g:test#haskell#cabaltest#test_command = 'test .'
+
+    view FixtureSpec.hs
+    TestSuite
+
+    Expect g:test#last_command == 'cabal test .'
+  end
+
+end
+

--- a/spec/fixtures/cabal/FixtureSpec.hs
+++ b/spec/fixtures/cabal/FixtureSpec.hs
@@ -1,0 +1,16 @@
+module FixtureSpec where
+import           Test.Hspec
+import           Test.QuickCheck
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+  it "returns the first element of an *arbitrary* list" $ property $ \x xs ->
+    head (x : xs) == (x :: Int)
+
+  it "throws an exception if used with an empty list"
+    $             evaluate (head [])
+    `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/multi-package/.gitignore
+++ b/spec/fixtures/cabal/multi-package/.gitignore
@@ -1,0 +1,4 @@
+.stack-work/
+stack.yaml.lock
+*.cabal
+*~

--- a/spec/fixtures/cabal/multi-package/.gitignore
+++ b/spec/fixtures/cabal/multi-package/.gitignore
@@ -1,4 +1,3 @@
 .stack-work/
 stack.yaml.lock
-*.cabal
 *~

--- a/spec/fixtures/cabal/multi-package/cabal.project
+++ b/spec/fixtures/cabal/multi-package/cabal.project
@@ -1,0 +1,6 @@
+with-compiler: ghc-9.2.8
+
+packages:
+  ./subpackage1/
+  ./subpackage2/
+  ./common/subpackage3/

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/.gitignore
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/.gitignore
@@ -1,0 +1,5 @@
+.stack-work/
+dist-newstyle
+stack.yaml.lock
+*.cabal
+*~

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/.gitignore
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 dist-newstyle
 stack.yaml.lock
-*.cabal
 *~

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/src/Lib.hs
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/subpackage3.cabal
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/subpackage3.cabal
@@ -1,0 +1,18 @@
+cabal-version: 3.8
+
+name:                subpackage3
+version:             0.1.0.0
+
+library
+  hs-source-dirs: src
+  build-depends:
+    base >= 4.7 && < 5
+
+test-suite single-project-test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  build-depends:
+    base >= 4.7 && < 5,
+    hspec

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/test/Fix3/FixtureSpec.hs
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/test/Fix3/FixtureSpec.hs
@@ -1,0 +1,19 @@
+module Fix3.FixtureSpec
+  ( module Test.Hspec -- Exported to validate that the correct module name is detected
+  , spec
+  ) where
+import           Test.Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+  prop "returns the first element of an *arbitrary* list" $ \x xs ->
+    head (x : xs) `shouldBe` (x :: Int)
+
+  describe "Empty list"
+    it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/multi-package/common/subpackage3/test/Spec.hs
+++ b/spec/fixtures/cabal/multi-package/common/subpackage3/test/Spec.hs
@@ -1,0 +1,6 @@
+module Spec() where
+import Fix2.FixtureSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/spec/fixtures/cabal/multi-package/subpackage1/.gitignore
+++ b/spec/fixtures/cabal/multi-package/subpackage1/.gitignore
@@ -1,0 +1,5 @@
+.stack-work/
+dist-newstyle/
+stack.yaml.lock
+*.cabal
+*~

--- a/spec/fixtures/cabal/multi-package/subpackage1/.gitignore
+++ b/spec/fixtures/cabal/multi-package/subpackage1/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 dist-newstyle/
 stack.yaml.lock
-*.cabal
 *~

--- a/spec/fixtures/cabal/multi-package/subpackage1/src/Lib.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage1/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/spec/fixtures/cabal/multi-package/subpackage1/subpackage1.cabal
+++ b/spec/fixtures/cabal/multi-package/subpackage1/subpackage1.cabal
@@ -1,0 +1,18 @@
+cabal-version: 3.8
+
+name:                subpackage1
+version:             0.1.0.0
+
+library
+  hs-source-dirs: src
+  build-depends:
+    base >= 4.7 && < 5
+
+test-suite single-project-test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  build-depends:
+    base >= 4.7 && < 5,
+    hspec

--- a/spec/fixtures/cabal/multi-package/subpackage1/test/Fix1/FixtureSpec.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage1/test/Fix1/FixtureSpec.hs
@@ -1,0 +1,19 @@
+module Fix1.FixtureSpec
+  ( module Test.Hspec -- Exported to validate that the correct module name is detected
+  , spec
+  ) where
+import           Test.Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+  prop "returns the first element of an *arbitrary* list" $ \x xs ->
+    head (x : xs) `shouldBe` (x :: Int)
+
+  describe "Empty list"
+    it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/multi-package/subpackage1/test/Spec.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage1/test/Spec.hs
@@ -1,0 +1,6 @@
+module Spec() where
+import Fix1.FixtureSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/spec/fixtures/cabal/multi-package/subpackage2/.gitignore
+++ b/spec/fixtures/cabal/multi-package/subpackage2/.gitignore
@@ -1,0 +1,5 @@
+.stack-work/
+dist-newstyle
+stack.yaml.lock
+*.cabal
+*~

--- a/spec/fixtures/cabal/multi-package/subpackage2/.gitignore
+++ b/spec/fixtures/cabal/multi-package/subpackage2/.gitignore
@@ -1,5 +1,4 @@
 .stack-work/
 dist-newstyle
 stack.yaml.lock
-*.cabal
 *~

--- a/spec/fixtures/cabal/multi-package/subpackage2/src/Lib.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage2/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/spec/fixtures/cabal/multi-package/subpackage2/subpackage2.cabal
+++ b/spec/fixtures/cabal/multi-package/subpackage2/subpackage2.cabal
@@ -1,0 +1,18 @@
+cabal-version: 3.8
+
+name:                subpackage2
+version:             0.1.0.0
+
+library
+  hs-source-dirs: src
+  build-depends:
+    base >= 4.7 && < 5
+
+test-suite single-project-test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  build-depends:
+    base >= 4.7 && < 5,
+    hspec

--- a/spec/fixtures/cabal/multi-package/subpackage2/test/Fix2/FixtureSpec.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage2/test/Fix2/FixtureSpec.hs
@@ -1,0 +1,16 @@
+module Fix2.FixtureSpec (spec) where
+import           Test.Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+  prop "returns the first element of an *arbitrary* list" $ \x xs ->
+    head (x : xs) `shouldBe` (x :: Int)
+
+  describe "Empty list"
+    it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/multi-package/subpackage2/test/Spec.hs
+++ b/spec/fixtures/cabal/multi-package/subpackage2/test/Spec.hs
@@ -1,0 +1,6 @@
+module Spec() where
+import Fix2.FixtureSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec

--- a/spec/fixtures/cabal/single-package/.gitignore
+++ b/spec/fixtures/cabal/single-package/.gitignore
@@ -1,0 +1,4 @@
+.stack-work/
+stack.yaml.lock
+*.cabal
+*~

--- a/spec/fixtures/cabal/single-package/.gitignore
+++ b/spec/fixtures/cabal/single-package/.gitignore
@@ -1,4 +1,3 @@
 .stack-work/
 stack.yaml.lock
-*.cabal
 *~

--- a/spec/fixtures/cabal/single-package/cabal.project
+++ b/spec/fixtures/cabal/single-package/cabal.project
@@ -1,0 +1,3 @@
+with-compiler: ghc-9.2.8
+
+packages: .

--- a/spec/fixtures/cabal/single-package/single-package.cabal
+++ b/spec/fixtures/cabal/single-package/single-package.cabal
@@ -1,0 +1,18 @@
+cabal-version: 3.8
+
+name:                single-package
+version:             0.1.0.0
+
+library
+  hs-source-dirs: src
+  build-depends:
+    base >= 4.7 && < 5
+
+test-suite single-project-test
+  main-is: Spec.hs
+  type: exitcode-stdio-1.0
+  hs-source-dirs:
+    test
+  build-depends:
+    base >= 4.7 && < 5,
+    hspec

--- a/spec/fixtures/cabal/single-package/src/Lib.hs
+++ b/spec/fixtures/cabal/single-package/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/spec/fixtures/cabal/single-package/test/Fix/Fixture2Spec.hs
+++ b/spec/fixtures/cabal/single-package/test/Fix/Fixture2Spec.hs
@@ -1,0 +1,21 @@
+module Fix.Fixture2Spec 
+  ( module Test.Hspec -- Exported to validate that the correct module name is detected
+  , spec
+  ) where
+
+import           Test.Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  describe "Non-empty list"
+    it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+    prop "returns the first element of an *arbitrary* list" $ \x xs ->
+      head (x : xs) `shouldBe` (x :: Int)
+
+  describe "Empty list"
+    it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/single-package/test/Fix/Fixture3Spec.hs
+++ b/spec/fixtures/cabal/single-package/test/Fix/Fixture3Spec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Fix.Fixture3Spec 
+  ( module Test.Hspec -- Exported to validate that the correct module name is detected
+  , spec
+  ) where
+
+import           Test.Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = describe "Prelude.head" $ do
+  describe "Non-empty list"
+    it "returns the first element of a list" $ head [23 ..] `shouldBe` (24 :: Int)
+
+    prop "returns the first element of an *arbitrary* list" $ \x xs ->
+      head (x : xs) `shouldBe` (x :: Int)
+
+  describe "Empty list"
+    it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `shouldThrow` anyException
+

--- a/spec/fixtures/cabal/single-package/test/Fix/FixtureSpec.hs
+++ b/spec/fixtures/cabal/single-package/test/Fix/FixtureSpec.hs
@@ -1,0 +1,18 @@
+module Fix.FixtureSpec ( module Hspec, spec ) where
+
+import qualified Test.Hspec as Hspec
+import           Control.Exception              ( evaluate )
+
+spec :: Spec
+spec = Hspec.describe "Prelude.head" $ do
+  Hspec.describe "Non-empty list"
+    Hspec.it "returns the first element of a list" $ head [23 ..] `Hspec.shouldBe` (24 :: Int)
+
+    Hspec.prop "returns the first element of an *arbitrary* list" $ \x xs ->
+      head (x : xs) `Hspec.shouldBe` (x :: Int)
+
+  describe "Empty list"
+    Hspec.it "throws an exception if used with an empty list"
+      $             evaluate (head [])
+      `Hspec.shouldThrow` anyException
+

--- a/spec/fixtures/cabal/single-package/test/Spec.hs
+++ b/spec/fixtures/cabal/single-package/test/Spec.hs
@@ -1,0 +1,6 @@
+module Spec() where
+import Fix.FixtureSpec (spec)
+import Test.Hspec (hspec)
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
`vim-test` already has a runner for `stack` and this adds `cabal` as another option. Both `stack` and `cabal` are used throughout the Haskell ecosystem, so it makes sense to support them both.

This runner is based on the `stacktest` runner. I duplicated the fixtures etc. so that each runner is self-contained (I saw that that was the approach taken for other languages with multiple runners e.g. Rust).

`stacktest` remains as the default for Haskell so that we don't break the experience for current users.

Thank you for creating and maintaining `vim-test`, it's awesome!

## PR template

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`