### PR TITLE
fix: delete buffer when closing vimterminal window

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -88,7 +88,7 @@ function! test#strategy#vimterminal(cmd) abort
   execute term_position . ' new'
   call term_start(!s:Windows() ? ['/bin/sh', '-c', a:cmd] : ['cmd.exe', '/c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
   au BufLeave <buffer> wincmd p
-  nnoremap <buffer> <Enter> :q<CR>
+  nnoremap <buffer> <Enter> :bd<CR>
   redraw
   echo "Press <Enter> to exit test runner terminal (<Ctrl-C> first if command is still running)"
 endfunction

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -87,7 +87,7 @@ function! test#strategy#vimterminal(cmd) abort
   let term_position = get(g:, 'test#vim#term_position', 'botright')
   execute term_position . ' new'
   call term_start(!s:Windows() ? ['/bin/sh', '-c', a:cmd] : ['cmd.exe', '/c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
-  au BufLeave <buffer> wincmd p
+  au BufDelete <buffer> wincmd p " switch back to last window
   nnoremap <buffer> <Enter> :bd<CR>
   redraw
   echo "Press <Enter> to exit test runner terminal (<Ctrl-C> first if command is still running)"


### PR DESCRIPTION
As mentioned in #763, pressing `<Enter>` in a vim terminal window closes it, but does not unload the buffer. This causes every test run to leave a lingering buffer behind, polluting the buffer list.

As far as I can tell, using `:bd` instead of `:q` to make sure the buffer is deleted does not have any drawbacks.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
