### PR TITLE
support Go 1.17 build tags

### DIFF
--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -27,7 +27,7 @@ function! test#go#gotest#build_args(args) abort
   endif
   let tags = []
   let index = 1
-  let pattern = '^//\s*+build\s\+\(.\+\)'
+  let pattern = '^//\s*\%(go:build\|+build\)\s\+\(.\+\)'
   while index <= getbufinfo('%')[0]['linecount']
     let line = trim(getbufline('%', l:index)[0])
     if l:line =~# '^package '
@@ -36,8 +36,12 @@ function! test#go#gotest#build_args(args) abort
     let tag = substitute(line, l:pattern, '\1', '')
     if l:tag != l:line
       " replace OR tags with AND, since we are going to use all the tags anyway
-      let tag = substitute(l:tag, ' \+', ',', 'g')
-      call add(l:tags, l:tag)
+      let tag = substitute(l:tag, '\v\&\&|\|\||\(|\)', '', 'g')
+      for val in split(l:tag, '[, ]\+')
+        if index(l:tags, l:val) == -1
+          call add(l:tags, l:val)
+        endif
+      endfor
     endif
     let index += 1
   endwhile

--- a/spec/fixtures/gotest/build_tags_117_test.go
+++ b/spec/fixtures/gotest/build_tags_117_test.go
@@ -1,0 +1,11 @@
+// some comments are allowed before tags
+
+//go:build foo && hello && world && !bar && (red || black)
+
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -110,6 +110,17 @@ describe "GoTest"
     Expect g:test#last_command == 'go test -tags=foo,hello,world,!bar,red,black'
   end
 
+  it "runs tests in a file with only Go 1.17 build tags"
+    view +10 build_tags_117_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -tags=foo,hello,world,!bar,red,black -run ''TestNumbers$'' ./.'
+
+    TestFile
+
+    Expect g:test#last_command == 'go test -tags=foo,hello,world,!bar,red,black'
+  end
+
   it "runs test suite without tags"
     view +14 build_tags_test.go
     TestSuite


### PR DESCRIPTION
- [x] Add fixtures and spec when implementing or updating a test runner

No updates to the README or Vim documentation are necessary

### Explanation

Go 1.17 added `//go:build` lines as the preferred way over `// +build` lines to specify build tags (see [Release Notes](https://go.dev/doc/go1.17)).

With the changes in this PR, `vim-test` will support both `//go:build` and `// +build` lines.

Fixes #751