### PR TITLE
Add neovim_sticky option to reopen hidden buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can customize this behavior with the following options:
 ```vim
 let g:test#neovim_sticky#kill_previous = 1  " Try to abort previous run
 let g:test#preserve_screen = 0  " Clear screen from previous run
-let test#neovim_sticky#reopen_window = 1 " Reopen terminal window if closed
+let test#neovim_sticky#reopen_window = 1 " Reopen terminal split if not visible
 ```
 
 ### Kitty strategy setup

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ You can customize this behavior with the following options:
 ```vim
 let g:test#neovim_sticky#kill_previous = 1  " Try to abort previous run
 let g:test#preserve_screen = 0  " Clear screen from previous run
+let test#neovim_sticky#reopen_window = 1 " Reopen terminal window if closed
 ```
 
 ### Kitty strategy setup

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -83,7 +83,10 @@ function! s:neovim_reopen_term(bufnr) abort
   let l:current_window = win_getid()
   let term_position = get(g:, 'test#neovim#term_position', 'botright')
   execute term_position . ' sbuffer ' . a:bufnr
+
+  let l:new_window = win_getid()
   call win_gotoid(l:current_window)
+  return l:new_window
 endfunction
 
 function! test#strategy#neovim(cmd) abort
@@ -117,12 +120,10 @@ function! test#strategy#neovim_sticky(cmd) abort
 
   let l:win = win_findbuf(l:buffers[0].bufnr)
   if !len(l:win) && get(g:, 'test#neovim_sticky#reopen_window', 0)
-    call s:neovim_reopen_term(l:buffers[0].bufnr)
+    let l:win = [s:neovim_reopen_term(l:buffers[0].bufnr)]
   endif
 
   call chansend(l:buffers[0].variables.terminal_job_id, l:cmd)
-
-  let l:win = win_findbuf(l:buffers[0].bufnr)
   if len(l:win) > 0
     call win_execute(l:win[0], 'normal G', 1)
   endif

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -79,6 +79,13 @@ function! s:neovim_new_term(cmd) abort
   call termopen(a:cmd)
 endfunction
 
+function! s:neovim_reopen_term(bufnr) abort
+  if !len(win_findbuf(a:bufnr))
+    let term_position = get(g:, 'test#neovim#term_position', 'botright')
+    execute term_position . ' sbuffer ' . a:bufnr
+  endif
+endfunction
+
 function! test#strategy#neovim(cmd) abort
   call s:neovim_new_term(a:cmd)
   au BufDelete <buffer> wincmd p " switch back to last window
@@ -105,6 +112,9 @@ function! test#strategy#neovim_sticky(cmd) abort
     endif
     if get(g:, 'test#neovim_sticky#kill_previous', 0)
       let l:cmd = [""] + l:cmd
+    endif
+    if get(g:, 'test#neovim_sticky#reopen_window', 0)
+      call s:neovim_reopen_term(l:buffers[0].bufnr)
     endif
   endif
 

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -80,10 +80,10 @@ function! s:neovim_new_term(cmd) abort
 endfunction
 
 function! s:neovim_reopen_term(bufnr) abort
-  if !len(win_findbuf(a:bufnr))
-    let term_position = get(g:, 'test#neovim#term_position', 'botright')
-    execute term_position . ' sbuffer ' . a:bufnr
-  endif
+  let l:current_window = win_getid()
+  let term_position = get(g:, 'test#neovim#term_position', 'botright')
+  execute term_position . ' sbuffer ' . a:bufnr
+  call win_gotoid(l:current_window)
 endfunction
 
 function! test#strategy#neovim(cmd) abort
@@ -113,13 +113,14 @@ function! test#strategy#neovim_sticky(cmd) abort
     if get(g:, 'test#neovim_sticky#kill_previous', 0)
       let l:cmd = [""] + l:cmd
     endif
-    if get(g:, 'test#neovim_sticky#reopen_window', 0)
-      call s:neovim_reopen_term(l:buffers[0].bufnr)
-    endif
   endif
 
   call chansend(l:buffers[0].variables.terminal_job_id, l:cmd)
   let l:win = win_findbuf(l:buffers[0].bufnr)
+  if !len(l:win) && get(g:, 'test#neovim_sticky#reopen_window', 0)
+    call s:neovim_reopen_term(l:buffers[0].bufnr)
+  endif
+
   if len(l:win) > 0
     call win_execute(l:win[0], 'normal G', 1)
   endif

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -115,12 +115,14 @@ function! test#strategy#neovim_sticky(cmd) abort
     endif
   endif
 
-  call chansend(l:buffers[0].variables.terminal_job_id, l:cmd)
   let l:win = win_findbuf(l:buffers[0].bufnr)
   if !len(l:win) && get(g:, 'test#neovim_sticky#reopen_window', 0)
     call s:neovim_reopen_term(l:buffers[0].bufnr)
   endif
 
+  call chansend(l:buffers[0].variables.terminal_job_id, l:cmd)
+
+  let l:win = win_findbuf(l:buffers[0].bufnr)
   if len(l:win) > 0
     call win_execute(l:win[0], 'normal G', 1)
   endif

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -642,7 +642,7 @@ scheduling a new one, use:
   let g:test#neovim_sticky#kill_previous = 1
 <
 To have the Neovim sticky strategy open an existing terminal in a new split
-when it was previously hidden, use:
+when it is not currently visible, use:
 >
     let test#neovim_sticky#reopen_window = 1
 <

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -641,6 +641,11 @@ scheduling a new one, use:
 >
   let g:test#neovim_sticky#kill_previous = 1
 <
+To have the Neovim sticky strategy open an existing terminal in a new split
+when it was previously hidden, use:
+>
+    let test#neovim_sticky#reopen_window = 1
+<
 You may find yourself specifying certain options for your test runners in
 certain situations. You can configure your preferred options with
 >


### PR DESCRIPTION
Adds a `test#neovim_sticky#reopen_window` option to the Neovim sticky strategy that will open a new split for the terminal if it's buffer was previously hidden.

Make sure these boxes are checked before submitting your pull request:

- [X] Add fixtures and spec when implementing or updating a test runner (N/A)
- [X] Update the README accordingly
- [X] Update the Vim documentation in `doc/test.txt`
