### PR TITLE
Support :TestNearest for EUnit runner

### DIFF
--- a/autoload/test/erlang/eunit.vim
+++ b/autoload/test/erlang/eunit.vim
@@ -1,5 +1,9 @@
 if !exists('g:test#erlang#eunit#file_pattern')
-  let g:test#erlang#eunit#file_pattern = '\v_tests\.erl$'
+  let g:test#erlang#eunit#file_pattern = '\v\C_tests\.erl$'
+endif
+
+if !exists('g:test#erlang#eunit#test_pattern')
+  let g:test#erlang#eunit#test_pattern = '\v\C^\s*(\w+_test_?)\s*\('
 endif
 
 function! test#erlang#eunit#test_file(file) abort
@@ -7,12 +11,36 @@ function! test#erlang#eunit#test_file(file) abort
 endfunction
 
 function! test#erlang#eunit#build_position(type, position) abort
-  let module = fnamemodify(a:position['file'],':t:r')
-  if a:type ==# 'nearest' || a:type ==# 'file'
-    return ['--module='.module]
-  else
-    return []
+  if a:type is# 'nearest'
+    let l:function = s:nearest_test(a:position)
+
+    if l:function[-6:] is# '_test_'
+      return ['--generator=' . s:module(a:position) . ':' . l:function]
+    endif
+
+    if l:function[-5:] is# '_test'
+      return ['--test=' . s:module(a:position) . ':' . l:function]
+    endif
   endif
+
+  if a:type isnot# 'suite'
+    return ['--module=' . s:module(a:position)]
+  endif
+
+  return []
+endfunction
+
+function! s:module(position) abort
+  return fnamemodify(a:position.file, ':t:r')
+endfunction
+
+function! s:nearest_test(position) abort
+  let l:nearest = test#base#nearest_test(a:position, {
+      \ 'test': [g:test#erlang#eunit#test_pattern],
+      \ 'namespace': [],
+      \})
+
+  return get(l:nearest.test, 0, '')
 endfunction
 
 function! test#erlang#eunit#build_args(args) abort

--- a/spec/eunit_spec.vim
+++ b/spec/eunit_spec.vim
@@ -1,7 +1,6 @@
 source spec/support/helpers.vim
 
-describe "EUnit"
-
+describe 'EUnit'
   before
     cd spec/fixtures/eunit
   end
@@ -11,28 +10,50 @@ describe "EUnit"
     cd -
   end
 
-  it "runs file tests"
-    view example_tests.erl
-    TestFile
+  context 'when executed with :TestFile'
+    it 'runs tests for corresponding module'
+      view example_tests.erl
+      TestFile
 
-    Expect g:test#last_command == 'rebar3 eunit --module=example_tests'
+      Expect g:test#last_command is# 'rebar3 eunit --module=example_tests'
+    end
   end
 
-  it "runs file tests instead of nearest tests"
-    view +8 example_tests.erl
-    TestNearest
+  context 'when executed with :TestNearest'
+    it 'runs the test under the cursor'
+      view +/simple_test/+1 example_tests.erl
+      TestNearest
 
-    Expect g:test#last_command == 'rebar3 eunit --module=example_tests'
+      Expect g:test#last_command is# 'rebar3 eunit --test=example_tests:simple_test'
+    end
+
+    it 'runs tests from the generator under the cursor'
+      view +/generator_test_/+1 example_tests.erl
+      TestNearest
+
+      Expect g:test#last_command is# 'rebar3 eunit --generator=example_tests:generator_test_'
+    end
+
+    context 'when there is no test or generator under the cursor'
+      it 'runs tests for corresponding module'
+        view +1 example_tests.erl
+        TestNearest
+
+        Expect g:test#last_command is# 'rebar3 eunit --module=example_tests'
+      end
+    end
   end
 
-  it "runs test suites"
-    view example_tests.erl
-    TestSuite
+  context 'when executed with :TestSuite'
+    it 'runs all test suites'
+      view example_tests.erl
+      TestSuite
 
-    Expect g:test#last_command == 'rebar3 eunit'
+      Expect g:test#last_command is# 'rebar3 eunit'
+    end
   end
 
-  it "ignores files not ending with _tests.erl"
+  it 'ignores files not ending with _tests.erl'
     view example_SUITE.erl
     TestFile
 

--- a/spec/fixtures/eunit/example_tests.erl
+++ b/spec/fixtures/eunit/example_tests.erl
@@ -2,8 +2,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-example1_test() ->
-  ?assert(ok =:= ok).
+simple_test() ->
+    ?assert(true).
 
-example2_test() ->
-  ?assert(ok =:= ok).
+generator_test_() ->
+    [?_assert(true)].


### PR DESCRIPTION
This PR allows to run individual test cases with EUnit runner for Erlang.

`--test` flag for `eunit` task is supported by Rebar3 for over a year (since 3.19), and `--generator` was added back in 2018.
