### PR TITLE
clojure: Expand patterns to support more use-cases

### DIFF
--- a/autoload/test/clojure.vim
+++ b/autoload/test/clojure.vim
@@ -1,7 +1,23 @@
+let s:line_start = '\v^\s*'
 " From https://clojure.org/reference/reader#_symbols
 let s:symbol_chars = "0-9a-zA-Z-*+!_'?<>="
+let s:word = '['.s:symbol_chars.']+'
+let s:ns_word = '['.s:symbol_chars.'.]+' " Namespaces can also have dots
+
+" We want to support both referred and qualified references to a test
+" definition function, i.e. both of these should work:
+" 
+"  (deftest ...)
+"  (clojure.test/deftest ...)
+"
+function! s:patterns(name)
+	let l:prefix = s:line_start.'\(\s*'
+	let l:suffix = '\s+('.s:word.')'
+	let l:qualified_name = s:ns_word.'\/'.a:name
+	return [l:prefix.a:name.l:suffix, l:prefix.l:qualified_name.l:suffix]
+endfunction
 
 let test#clojure#patterns = {
-  \ 'test':      ['(deftest \(['.s:symbol_chars.']\+\)'],
-  \ 'namespace': ['(ns \(['.s:symbol_chars.'.]\+\)'],
+  \ 'test':      s:patterns('deftest') + s:patterns('defspec'),
+  \ 'namespace': [s:line_start.'\(ns\s+('.s:ns_word.')'],
   \}

--- a/autoload/test/clojure/leintest.vim
+++ b/autoload/test/clojure/leintest.vim
@@ -16,13 +16,13 @@ function! test#clojure#leintest#build_position(type, position) abort
   let l:info = test#base#nearest_test(a:position, g:test#clojure#patterns, {'namespaces_with_same_indent': v:true})
   if a:type ==# 'nearest'
     if !empty(l:info['namespace']) && !empty(l:info['test'])
-      return [':only', l:info['namespace'][0].'/'.l:info['test'][0]]
+      return [':only', shellescape(l:info['namespace'][0].'/'.l:info['test'][0])]
     else
       throw 'No test found'
     endif
   elseif a:type ==# 'file'
     if !empty(l:info['namespace'])
-      return [':only', l:info['namespace'][0]]
+      return [':only', shellescape(l:info['namespace'][0])]
     else
       throw 'No namespace found'
     endif

--- a/spec/fixtures/clojure/math_test.clj
+++ b/spec/fixtures/clojure/math_test.clj
@@ -1,9 +1,21 @@
-(ns math-test)
+(ns math-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]))
 
-(deftest a-test
-  (testing "Test 1"
-    (is (= 1 1))))
+(deftest +-works
+  (is (= 4 (+ 2 2))))
 
-(deftest another-test
-  (testing "Test 2"
-    (is (= 1 1))))
+(clojure.test/deftest *-works
+  (is (= 4 (* 2 2))))
+
+(defspec +-is-commutative
+  (prop/for-all [a gen/large-integer
+                 b gen/large-integer]
+                (= (+ a b) (+ b a))))
+
+(clojure.test.check.clojure-test/defspec *-is-commutative
+  (prop/for-all [a gen/small-integer
+                 b gen/small-integer]
+                (= (* a b) (* b a))))

--- a/spec/leintest_spec.vim
+++ b/spec/leintest_spec.vim
@@ -29,26 +29,26 @@ describe "LeinTest"
   it "runs nearest tests"
     view +7 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# 'lein test :only math-test/+-works'
+    Expect g:test#last_command =~# "lein test :only 'math-test/+-works'"
 
     view +10 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# 'lein test :only math-test/*-works'
+    Expect g:test#last_command =~# "lein test :only 'math-test/*-works'"
 
     view +13 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# 'lein test :only math-test/+-is-commutative'
+    Expect g:test#last_command =~# "lein test :only 'math-test/+-is-commutative'"
 
     view +18 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# 'lein test :only math-test/*-is-commutative'
+    Expect g:test#last_command =~# "lein test :only 'math-test/*-is-commutative'"
   end
 
   it "runs file tests"
     view math_test.clj
     TestFile
 
-    Expect g:test#last_command =~# 'lein test :only math-test'
+    Expect g:test#last_command =~# "lein test :only 'math-test'"
   end
 
   it "runs test suites"

--- a/spec/leintest_spec.vim
+++ b/spec/leintest_spec.vim
@@ -14,47 +14,47 @@ describe "LeinTest"
 
   it "recognizes test files"
     view math_test.clj | TestSuite
-    Expect g:test#last_position['file'] == 'math_test.clj'
+    Expect g:test#last_position['file'] ==# 'math_test.clj'
 
     view math_test.cljs | TestSuite
-    Expect g:test#last_position['file'] == 'math_test.cljs'
+    Expect g:test#last_position['file'] ==# 'math_test.cljs'
 
     view test/math.clj | TestSuite
-    Expect g:test#last_position['file'] == 'test/math.clj'
+    Expect g:test#last_position['file'] ==# 'test/math.clj'
 
     view test/math.cljs | TestSuite
-    Expect g:test#last_position['file'] == 'test/math.cljs'
+    Expect g:test#last_position['file'] ==# 'test/math.cljs'
   end
 
   it "runs nearest tests"
     view +7 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# "lein test :only 'math-test/+-works'"
+    Expect g:test#last_command ==# "lein test :only 'math-test/+-works'"
 
     view +10 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# "lein test :only 'math-test/*-works'"
+    Expect g:test#last_command ==# "lein test :only 'math-test/*-works'"
 
     view +13 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# "lein test :only 'math-test/+-is-commutative'"
+    Expect g:test#last_command ==# "lein test :only 'math-test/+-is-commutative'"
 
     view +18 math_test.clj
     TestNearest
-    Expect g:test#last_command =~# "lein test :only 'math-test/*-is-commutative'"
+    Expect g:test#last_command ==# "lein test :only 'math-test/*-is-commutative'"
   end
 
   it "runs file tests"
     view math_test.clj
     TestFile
 
-    Expect g:test#last_command =~# "lein test :only 'math-test'"
+    Expect g:test#last_command ==# "lein test :only 'math-test'"
   end
 
   it "runs test suites"
     view math_test.clj
     TestSuite
 
-    Expect g:test#last_command =~# 'lein test :all'
+    Expect g:test#last_command ==# 'lein test :all'
   end
 end

--- a/spec/leintest_spec.vim
+++ b/spec/leintest_spec.vim
@@ -27,10 +27,21 @@ describe "LeinTest"
   end
 
   it "runs nearest tests"
-    view +3 math_test.clj
+    view +7 math_test.clj
     TestNearest
+    Expect g:test#last_command =~# 'lein test :only math-test/+-works'
 
-    Expect g:test#last_command =~# 'lein test :only math-test/a-test'
+    view +10 math_test.clj
+    TestNearest
+    Expect g:test#last_command =~# 'lein test :only math-test/*-works'
+
+    view +13 math_test.clj
+    TestNearest
+    Expect g:test#last_command =~# 'lein test :only math-test/+-is-commutative'
+
+    view +18 math_test.clj
+    TestNearest
+    Expect g:test#last_command =~# 'lein test :only math-test/*-is-commutative'
   end
 
   it "runs file tests"


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

This PR updates the Clojure test patterns to support a few additional use-cases. The pattern originally only supported tests defined as `(deftest ...`, but with this change now also supports

1. Qualified `deftest` (i.e. `(clojure.test/deftest ...`)
2. [`defspec`](http://clojure.github.io/test.check/clojure.test.check.clojure-test.html#var-defspec)
3. Qualified `defspec`

It also updates the Leiningen test runner to wrap the test name in `shellescape()`, since Clojure supports a number of additional characters that wreak havoc with Bash.