### PR TITLE
feat: support for go stretchr/testify

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,16 +582,6 @@ If `delve` is selected and [vim-delve](https://github.com/sebdah/vim-delve) is
 in use, breakpoints and tracepoints that have been marked with vim-delve will
 be included.
 
-If you use stretchr/testify run your nearest testcase
-To let your testify case work
-
-```vim
-let g:test#go#gotest#testify#enabled = 1
-```
-
-This setting modifies the Go test arguments to `-testify.m {NearestFunction} -run {TestSuiteName}`
-Here, TestSuiteName refers to the first testcase that uses `testing.T`
-
 #### Ruby
 
 Unless binstubs are detected (e.g. `bin/rspec`), test commands will

--- a/README.md
+++ b/README.md
@@ -582,6 +582,16 @@ If `delve` is selected and [vim-delve](https://github.com/sebdah/vim-delve) is
 in use, breakpoints and tracepoints that have been marked with vim-delve will
 be included.
 
+If you use stretchr/testify run your nearest testcase
+To let your testify case work
+
+```vim
+let g:test#go#gotest#testify#enabled = 1
+```
+
+This setting modifies the Go test arguments to `-testify.m {NearestFunction} -run {TestSuiteName}`
+Here, TestSuiteName refers to the first testcase that uses `testing.T`
+
 #### Ruby
 
 Unless binstubs are detected (e.g. `bin/rspec`), test commands will

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -2,10 +2,6 @@ if !exists('g:test#go#gotest#file_pattern')
   let g:test#go#gotest#file_pattern = '\v[^_].*_test\.go$'
 endif
 
-if !exists('g:test#go#gotest#testify#enabled')
-  let g:test#go#gotest#testify#enabled = 0
-endif
-
 function! test#go#gotest#test_file(file) abort
   return test#go#test_file('gotest', g:test#go#gotest#file_pattern, a:file)
 endfunction
@@ -20,7 +16,7 @@ function! test#go#gotest#build_position(type, position) abort
       return path ==# './.' ? [] : [path . '/...']
     elseif a:type ==# 'nearest'
        
-      if g:test#go#gotest#testify#enabled == 1 && s:is_testify() == 1
+      if s:is_testify() == 1
           let suite_name = s:get_suite_name()
           let name = s:nearest_test(a:position)
           return empty(name) ? [] : [path, '-run '.shellescape(suite_name.'$') . ' -testify.m ' .shellescape(name, 1)]

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -2,6 +2,10 @@ if !exists('g:test#go#gotest#file_pattern')
   let g:test#go#gotest#file_pattern = '\v[^_].*_test\.go$'
 endif
 
+if !exists('g:test#go#gotest#testify#enabled')
+  let g:test#go#gotest#testify#enabled = 0
+endif
+
 function! test#go#gotest#test_file(file) abort
   return test#go#test_file('gotest', g:test#go#gotest#file_pattern, a:file)
 endfunction
@@ -15,8 +19,8 @@ function! test#go#gotest#build_position(type, position) abort
     if a:type ==# 'file'
       return path ==# './.' ? [] : [path . '/...']
     elseif a:type ==# 'nearest'
-      let matched_testify = s:is_testify()
-      if matched_testify == 1
+       
+      if g:test#go#gotest#testify#enabled == 1 && s:is_testify() == 1
           let suite_name = s:get_suite_name()
           let name = s:nearest_test(a:position)
           return empty(name) ? [] : [path, '-run '.shellescape(suite_name.'$') . ' -testify.m ' .shellescape(name, 1)]
@@ -91,3 +95,4 @@ function! s:nearest_test(position) abort
   echo escaped_regex
   return escaped_regex
 endfunction
+

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -92,7 +92,6 @@ function! s:nearest_test(position) abort
   let name = join(name['namespace'] + name['test'], '/')
   let without_spaces = substitute(name, '\s', '_', 'g')
   let escaped_regex = substitute(without_spaces, '\([\[\].*+?|$^()]\)', '\\\1', 'g')
-  echo escaped_regex
   return escaped_regex
 endfunction
 

--- a/spec/fixtures/gotest/testify_test.go
+++ b/spec/fixtures/gotest/testify_test.go
@@ -1,0 +1,23 @@
+package mypackage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ExampleSuite struct {
+	suite.Suite
+}
+
+func (s *ExampleSuite) TestList() {
+	a := []int{1, 2, 3}
+	s.NotEmpty(a)
+}
+
+func (s *ExampleSuite) SetupTest() {
+}
+
+func TestExampleTestSuite(t *testing.T) {
+	suite.Run(t, new(ExampleSuite))
+}

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -71,6 +71,14 @@ describe "GoTest"
     Expect g:test#last_command == 'go test -run ''TestSomething$'' ./mypackage'
   end
 
+  it "runs nearest testify case"
+    let g:test#go#gotest#testify#enabled = 1
+    view +14 testify_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test ./. -run ''TestExampleTestSuite$'' -testify.m ''TestList'''
+  end
+
   it "runs file test if nearest test couldn't be found"
     view +1 normal_test.go
     TestNearest

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -72,7 +72,6 @@ describe "GoTest"
   end
 
   it "runs nearest testify case"
-    let g:test#go#gotest#testify#enabled = 1
     view +14 testify_test.go
     TestNearest
 


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

Hi, I  implement the issue https://github.com/vim-test/vim-test/issues/624
and I think the document  is added by PR #694
I hope I can help it.


And It supposes that the user imports "testify/suite" and there is only one general Go test (the test has testing.T) as Test{X}Suite.

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
