### PR TITLE
feat: support go testify for multiple suite and original testcase

### DIFF
--- a/spec/fixtures/gotest/testify_test.go
+++ b/spec/fixtures/gotest/testify_test.go
@@ -10,12 +10,28 @@ type ExampleSuite struct {
 	suite.Suite
 }
 
+type AnotherSuite struct {
+	suite.Suite
+}
+
 func (s *ExampleSuite) TestList() {
 	a := []int{1, 2, 3}
 	s.NotEmpty(a)
 }
 
+func (s *AnotherSuite) TestAnother() {
+	a := []int{1, 2, 3}
+	s.NotEmpty(a)
+}
+
 func (s *ExampleSuite) SetupTest() {
+}
+
+func TestOriginalTestcase(t *testing.T) {
+}
+
+func TestAnotherTestSuite(t *testing.T) {
+	suite.Run(t, new(AnotherSuite))
 }
 
 func TestExampleTestSuite(t *testing.T) {

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -72,10 +72,25 @@ describe "GoTest"
   end
 
   it "runs nearest testify case"
-    view +14 testify_test.go
+    view +18 testify_test.go
     TestNearest
 
     Expect g:test#last_command == 'go test ./. -run ''TestExampleTestSuite$'' -testify.m ''TestList'''
+
+    view +18 testify_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test ./. -run ''TestExampleTestSuite$'' -testify.m ''TestList'''
+
+    view +23 testify_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test ./. -run ''TestAnotherTestSuite$'' -testify.m ''TestAnother'''
+
+    view +30 testify_test.go
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''TestOriginalTestcase$'' ./.'
   end
 
   it "runs file test if nearest test couldn't be found"


### PR DESCRIPTION
In this PR https://github.com/vim-test/vim-test/pull/781 I suppose the user only uses one original Golang testcase
I tried to improve the script to support more complicated situations 

1. run multiple suites
2. mix testify suite and original Golang testcase

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
