### PR TITLE
Update minitest.vim to use ruby args by default for when runner name does not contain ruby/rake

### DIFF
--- a/autoload/test/ruby/minitest.vim
+++ b/autoload/test/ruby/minitest.vim
@@ -43,6 +43,7 @@ function! test#ruby#minitest#build_args(args) abort
   endfor
 
   let kind = matchstr(test#base#executable('ruby#minitest'), 'ruby\|rake')
+  let kind = empty(kind) ? 'ruby' : kind
   return s:build_{kind}_args(get(l:, 'path'), a:args)
 endfunction
 


### PR DESCRIPTION
If you have a strategy that uses `bin/test` to run, it will not match against 'ruby' or 'rake'.

My suggestion is we fall back to ruby when neither is present. While this does presume ruby as the default, the alternative is it not working.

I'd also be happy to make this a configuration option instead if that makes more sense.


Make sure these boxes are checked before submitting your pull request:

**NOTE:** Regarding these checkboxes:
- There are no fixtures or specs for using minitest with ruby in general, just for rake.
- Don't think the README needs to be updated
- I don't see a need for an update in doc/text.txt.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

