### PR TITLE
Allow setting a dynamic project_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,15 @@ different working directory for running tests:
 let test#project_root = "/path/to/your/project"
 ```
 
+Alternatively you can pass in a function that'll be evaluated before each test run.
+```vim
+function! CustomPath()
+  return "~/Project"
+endfunction
+
+let test#project_root = function('CustomPath')
+```
+
 ### Language-specific
 
 #### Python
@@ -465,10 +474,10 @@ let test#python#runner = 'pytest'
 The `pytest` and `djangotest` runner optionally supports [pipenv](https://github.com/pypa/pipenv).
 If you have a `Pipfile`, it will use `pipenv run pytest` instead of just
 `python -m pytest`. They also support [poetry](https://github.com/sdispater/poetry)
-and will use `poetry run pytest` if it detects a `poetry.lock`. The pyunit and nose 
+and will use `poetry run pytest` if it detects a `poetry.lock`. The pyunit and nose
 runner supports [pipenv](https://github.com/pypa/pipenv) as well and will
-respectively use `pipenv run python -m unittest` or `pipenv run python -m nosetests` 
-if there is a `Pipfile`. It also supports [pdm](https://pdm.fming.dev/) as well and 
+respectively use `pipenv run python -m unittest` or `pipenv run python -m nosetests`
+if there is a `Pipfile`. It also supports [pdm](https://pdm.fming.dev/) as well and
 will use `poetry run pytest` if there is a `pdm.lock` file.
 
 #### Java
@@ -661,7 +670,7 @@ let g:test#cpp#catch2#relToProject_build_dir = "."
 ```
 We assume that your compiled executables are stored in `build` directory. If not, you can override this with:
 ```vim
-let g:test#cpp#catch2#bin_dir = "../path/to/your/binaries/dir" 
+let g:test#cpp#catch2#bin_dir = "../path/to/your/binaries/dir"
 ```
 Suite: We assume that you are using Cmake as your build system, and are registering each test file to it. If not, override the following command.
 ```vim

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -171,7 +171,11 @@ function! s:before_run() abort
   endif
 
   if exists('g:test#project_root')
-    execute 'cd' g:test#project_root
+    if type(g:test#project_root) == v:t_func
+      execute 'cd' g:test#project_root()
+    else
+      execute 'cd' g:test#project_root
+    endif
   endif
 endfunction
 

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -720,6 +720,14 @@ working directory for running tests:
 >
   let test#project_root = "/path/to/your/project"
 <
+Alternatively you can pass in a function that'll be evaluated before each test run:
+>
+  function! CustomPath()
+    return "~/Project"
+  endfunction
+
+  let test#project_root = function('CustomPath')
+<
 Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the
 bottom by default, but you can configure a different position or orientation.
 Whatever you put here is passed to `new` - so, you may also specify size (see


### PR DESCRIPTION
I wanted to dynamically set the project_root and found the easiest way to do that is by allowing it to be a function. That way I can very flexibly decide where the project root is.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
