### PR TITLE
Add split pane percent to WezTerm strategy

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -243,7 +243,8 @@ function! test#strategy#wezterm(cmd) abort
     if l:output[0] == $WEZTERM_PANE
       let l:prev = $WEZTERM_PANE
       let l:dir = get(g:, "test#wezterm#split_direction", "right")
-      let l:output = systemlist([l:wezterm, "cli", "split-pane", "--" . l:dir])
+      let l:width = get(g:, "test#wezterm#split_percent", 50)
+      let l:output = systemlist([l:wezterm, "cli", "split-pane", "--percent", l:width, "--" . l:dir])
 
       " return to original pane
       call system([l:wezterm, "cli", "activate-pane", "--pane-id", l:prev])

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -578,6 +578,15 @@ overriden with `g:test#wezterm#split_direction`.
   let g:test#wezterm#split_direction = 'bottom'
 <
 
+The wezterm cli split-pane accepts a --percent option to customize the number
+of cells that the new split will have, expressed as a percentage. The percent
+defaults to 50 unless set to a different value.
+
+>
+  let test#wezterm#split_percent = 30
+<
+
+
 QUICKFIX STRATEGIES                               *test-quickfix-strategies*
 
 If you want your test results to appear in the |quickfix| window, use one of the


### PR DESCRIPTION
The `split-pane` command creates a split that's 50% of the screen width when split using `--right`. This may be wider than some preferred. This adds a `split_percent` option to customize the width of the split pane.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
