### PR TITLE
Support gotest args

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,11 @@ let test#rust#cargotest#test_options = {
 \}
 ```
 
+The gotest runner let you specify the -args argument as follows:
+```vim
+let test#go#gotest#args = 'a=b'
+```
+
 ### Vim8 / Neovim terminal position
 
 Both the `neovim` and `Vim8 Terminal` strategy will open a split window on the

--- a/autoload/test/go/gotest.vim
+++ b/autoload/test/go/gotest.vim
@@ -9,8 +9,13 @@ endfunction
 let s:original_testcase_pattern = '\v^\s*func ((Test|Example).*)\(.*testing\.T'
 
 function! test#go#gotest#build_position(type, position) abort
+  let l:gotest_args = ''
+  if exists('g:test#go#gotest#args')
+    let l:gotest_args = '-args ' . g:test#go#gotest#args
+  endif
+
   if a:type ==# 'suite'
-    return ['./...']
+    return ['./...', l:gotest_args]
   else
     let path = './'.fnamemodify(a:position['file'], ':h')
 
@@ -26,7 +31,8 @@ function! test#go#gotest#build_position(type, position) abort
         endif
       endif
       let name = s:nearest_test(a:position)
-      return empty(name) ? [] : ['-run '.shellescape(name.'$', 1), path]
+      let command = empty(name) ? [] : ['-run '.shellescape(name.'$', 1), path]
+      return add(command, l:gotest_args)
     endif
   endif
 endfunction

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -709,6 +709,10 @@ Or using a more granular approach:
     \ 'nearest': ['--', '--nocapture', '--exact'],
     \ 'file':    [],
   \}
+
+The gotest runner let you specify the -args argument as follows:
+>
+  let g:test#go#gotest#args = 'a=b'
 <
 If you want to manually configure a test runner's executable, you can do
 >

--- a/spec/gotest_spec.vim
+++ b/spec/gotest_spec.vim
@@ -149,4 +149,20 @@ describe "GoTest"
 
     Expect g:test#last_command == 'go test ./...'
   end
+
+  it "runs test with args"
+    view +5 normal_test.go
+    let g:test#go#gotest#args = "a=b"
+    TestNearest
+
+    Expect g:test#last_command == 'go test -run ''TestNumbers$'' ./. -args a=b'
+  end
+
+  it "runs test suite with args"
+    view +14 build_tags_test.go
+    let g:test#go#gotest#args = "a=b"
+    TestSuite
+
+    Expect g:test#last_command == 'go test ./... -args a=b'
+  end
 end


### PR DESCRIPTION
specifically
-args
    Pass the remainder of the command line (everything after -args)
    to the test binary, uninterpreted and unchanged.
    Because this flag consumes the remainder of the command line,
    the package list (if present) must appear before this flag.

https://pkg.go.dev/cmd/go/internal/test#pkg-index

Make sure these boxes are checked before submitting your pull request:

btw, i am not very sure where to write the docs as this is very go specific

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
