### PR TITLE
fix: correct escaping for Vitest nearest

### DIFF
--- a/autoload/test/javascript/vitest.vim
+++ b/autoload/test/javascript/vitest.vim
@@ -16,7 +16,7 @@ function! test#javascript#vitest#build_position(type, position) abort
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
-      let name = '-t '.shellescape(name, 1)
+      let name = '-t '.shellescape(escape(name, '()[]'), 1)
     endif
     return ['run', name, a:position['file']]
   elseif a:type ==# 'file'

--- a/spec/fixtures/vitest/__tests__/escaping-test.ts
+++ b/spec/fixtures/vitest/__tests__/escaping-test.ts
@@ -1,0 +1,8 @@
+describe('Escaping', () => {
+  it('parentheses (', () => {
+    // assertions
+  });
+  it('brackets [', () => {
+    // assertions
+  });
+});

--- a/spec/vitest_spec.vim
+++ b/spec/vitest_spec.vim
@@ -33,6 +33,16 @@ describe "vitest"
       TestNearest
 
       Expect g:test#last_command == g:expectedExecutable .. 'vitest run -t ''Math Addition adds two numbers'' __tests__/normal-test.jsx'
+
+      view +2 __tests__/escaping-test.ts
+      TestNearest
+
+      Expect g:test#last_command == g:expectedExecutable .. 'vitest run -t ''Escaping parentheses \\('' __tests__/escaping-test.ts'
+
+      view +5 __tests__/escaping-test.ts
+      TestNearest
+
+      Expect g:test#last_command == g:expectedExecutable .. 'vitest run -t ''Escaping brackets \\['' __tests__/escaping-test.ts'
     end
 
     it "runs loop tests"


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
