### PR TITLE
Cargo feature/allow named packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,6 +702,10 @@ If the `nextest` cargo subcommand is available, cargo-nextest is used. `cargo te
 let g:test#rust#runner = 'cargotest'
 ```
 
+In workspaces, reads the [package name field] from `Cargo.toml'.
+
+[package name field]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field
+
 ## Autocommands
 
 In addition to running tests manually, you can also configure autocommands

--- a/autoload/test/rust/cargonextest.vim
+++ b/autoload/test/rust/cargonextest.vim
@@ -114,6 +114,17 @@ function! s:test_namespace(filename) abort
           echo
           let l:package = l:modules[idx]
           let l:modules = l:modules[idx+1:]
+          " use package name, if present
+          let l:section = ''
+          for line in readfile(l:cargo_toml)
+            if line =~ '\[.\+\]' | let l:section = line | endif
+              if l:section == '[package]' && line =~ 'name'
+              let l:package = matchstr(line, '"\zs[^"]*\ze"')
+
+              break
+            endif
+          endfor
+
           break
       endif
   endfor

--- a/autoload/test/rust/cargotest.vim
+++ b/autoload/test/rust/cargotest.vim
@@ -133,6 +133,17 @@ function! s:test_namespace(filename) abort
           echo 
           let l:package = l:modules[idx]
           let l:modules = l:modules[idx+1:]
+          " use package name, if present
+          let l:section = ''
+          for line in readfile(l:cargo_toml)
+            if line =~ '\[.\+\]' | let l:section = line | endif
+              if l:section == '[package]' && line =~ 'name'
+              let l:package = matchstr(line, '"\zs[^"]*\ze"')
+
+              break
+            endif
+          endfor
+
           break
       endif
   endfor

--- a/spec/cargonextest_spec.vim
+++ b/spec/cargonextest_spec.vim
@@ -155,6 +155,6 @@ describe "CargoNextest"
     cd ..
     view crate/src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo nextest run --package crate '''''
+    Expect g:test#last_command == 'cargo nextest run --package vim-test '''''
     cd -
 end

--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -216,12 +216,12 @@ describe "Cargo"
     cd ..
     view crate/src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo test --package crate '''''
+    Expect g:test#last_command == 'cargo test --package vim-test '''''
 
     let g:test#rust#cargotest#test_options = {'nearest': '-- --nocapture --exact', 'file': ['-- --nocapture']}
     view crate/src/lib.rs
     TestFile
-    Expect g:test#last_command == 'cargo test --package crate '''' -- --nocapture'
+    Expect g:test#last_command == 'cargo test --package vim-test '''' -- --nocapture'
     unlet g:test#rust#cargotest#test_options
     cd -
   end

--- a/spec/fixtures/cargo/crate/Cargo.toml
+++ b/spec/fixtures/cargo/crate/Cargo.toml
@@ -1,0 +1,8 @@
+[some-section]
+name = "not me"
+
+[package]
+name = "vim-test"
+
+[some-other-section]
+name = "not me either"


### PR DESCRIPTION
Updates `cargotest` and `cargonexttest` scripts to read `pakage.name` from `Cargo.toml` instead of relying only on the directory name.

Fixes https://github.com/vim-test/vim-test/issues/807

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
  ^ doesn't look like it is necessary
