### PR TITLE
Run `pest` via `sail` when configured

### DIFF
--- a/autoload/test/php/pest.vim
+++ b/autoload/test/php/pest.vim
@@ -41,7 +41,9 @@ function! test#php#pest#build_args(args, color) abort
 endfunction
 
 function! test#php#pest#executable() abort
-  if filereadable('./vendor/bin/pest')
+  if filereadable('./vendor/bin/sail') && (filereadable('./docker-compose.yml') || filereadable('./docker-compose.yaml'))
+    return './vendor/bin/sail pest'
+  elseif filereadable('./vendor/bin/pest')
     return './vendor/bin/pest'
   elseif filereadable('./bin/pest')
     return './bin/pest'

--- a/spec/sail_spec.vim
+++ b/spec/sail_spec.vim
@@ -11,7 +11,7 @@ describe "Laravel Sail"
 
   after
     call Teardown()
-    !rm -rf vendor
+    !rm -rf vendor docker-compose.yml
     cd -
   end
 
@@ -96,6 +96,20 @@ describe "Laravel Sail"
     TestFile
 
     Expect g:test#last_command == 'phpunit --colors NormalTest.php'
+  end
+
+  it "runs Pest via sail when configured"
+    cd ../pest
+    !mkdir -p vendor/bin
+    !touch vendor/bin/sail
+    !touch docker-compose.yml
+    view PestTest.php
+    TestFile
+
+    Expect g:test#last_command == './vendor/bin/sail pest --colors PestTest.php'
+
+    !rm -rf vendor docker-compose.yml
+    cd ../phpunit
   end
 
 end


### PR DESCRIPTION
This PR adds support for running Pest test suites via Laravel Sail automatically.

Sail is already detected for PHPUnit testsuites. This uses the same mechanism.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

I have not updated the readme or docs as this feels more like an enhancement than a feature worth documenting.