### PR TITLE
Add optional prompt when executing tests with unsaved files

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,6 +810,20 @@ $ vim-flavor test spec/
 
 Or if you're inside of Vim, you can simply run `:VSpec` provided by test.vim.
 
+## Unsaved changes
+
+If `autowrite` or `autowriteall` are set then unsaved changes will be
+written to disk with `:wall` before each test execution.
+
+### Prompt for unsaved changes
+
+You can enable a user prompt asking whether to write unsaved changes
+prior to executing a test by
+
+```vim
+  let g:test#prompt_for_unsaved_changes = 1
+```
+
 ## Credits
 
 This plugin was strongly influenced by Gary Bernhardt's Destroy All Software.

--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -166,8 +166,20 @@ function! s:alternate_file() abort
 endfunction
 
 function! s:before_run() abort
+  let modified_buffers = len(getbufinfo({'bufmodified': 1}))
   if &autowrite || &autowriteall
     silent! wall
+
+  elseif exists('g:test#prompt_for_unsaved_changes') && l:modified_buffers
+    let answer = confirm(
+        \ "Warning: you have unsaved changes",
+        \ "&write\nwrite &all\n&continue", 3)
+
+    if l:answer == 1
+      write
+    elseif l:answer == 2
+      wall
+    endif
   endif
 
   if exists('g:test#project_root')

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -11,6 +11,8 @@ License: Same terms as Vim itself (see |license|)
 |test-configuration|              CONFIGURATION
 |test-python|                     PYTHON SPECIFIC CONFIG
 |test-projectionist|              PROJECTIONIST INTEGRATION
+|test-custom-alternate-file|      CUSTOM ALTERNATE FILE
+|test-unsaved-changes|            UNSAVED CHANGES
 |test-about|                      ABOUT
 |test-credits|                    CREDITS
 
@@ -822,6 +824,19 @@ function! CustomAlternateFile(cmd)
 endfunction
 
 let g:test#custom_alternate_file = function('CustomAlternateFile')
+<
+
+UNSAVED CHANGES                                 *test-unsaved-changes*
+
+If |'autowrite'| or |'autowriteall'| are set then unsaved changes will be
+written to disk with |:wall| before each test execution.
+
+Prompt for unsaved changes ~
+
+You can enable a user prompt asking whether to write unsaved changes
+prior to executing a test by
+>
+  let g:test#prompt_for_unsaved_changes = 1
 <
 
 ABOUT                                           *test-about*


### PR DESCRIPTION
Adds an optional user prompt when executing tests with unsaved files. Also adds documentation for how `autowrite` is handled within vim-test. Fixes #723.

<hr>
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
