### PR TITLE
Fix term_position usage in s:neovim_reopen_term

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -90,7 +90,7 @@ endfunction
 function! s:neovim_reopen_term(bufnr) abort
   let l:current_window = win_getid()
   let term_position = get(g:, 'test#neovim#term_position', 'botright')
-  execute term_position . ' sbuffer ' . a:bufnr
+  execute term_position . ' new | buffer ' . a:bufnr
 
   let l:new_window = win_getid()
   call win_gotoid(l:current_window)


### PR DESCRIPTION
If `test#neovim#term_position` is set to something like `botright 10` to setup a terminal that is 10 in height and we need to reopen the terminal since it isn't visible, the current `s:neovim_reopen_term()` function doesn't correctly re-open the terminal with the appropriate height. This PR addresses this by running something like `botright 10 new | buffer [bufnr]` which sets the height correctly instead of `botright 10 sbuffer [bufnr]` which doesn't.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
