### PR TITLE
Maven: fix multimodule when one submodule depends on another

### DIFF
--- a/doc/test.txt
+++ b/doc/test.txt
@@ -286,7 +286,7 @@ for example:
 :Prove [args]                Uses the `prove` command.
 
                                                 *test-:MavenTest*
-:MavenTest [args]            Uses the `mvn` `test` command. If the file exists in a multi-module project then appends -pl <modulename> and runs a single module only. There is a different strategy for running tests with the failsafe plugin instead of surefire. It is described in detail in the test-maven-test-differences section.
+:MavenTest [args]            Uses the `mvn` `test` command. If the file exists in a multi-module project then appends -am -pl <modulename> and disables `failIfNoSpecifiedTests`, and runs a single module only. There is a different strategy for running tests with the failsafe plugin instead of surefire. It is described in detail in the test-maven-test-differences section.
                                                 *test-:GradleTest*
 :GradleTest [args]           Uses the `gradle` `test` command. If the project is multi module then it uses the -p <modulename> flag.
 

--- a/spec/fixtures/maven/sample_maven_junit3_multimodule_project/sample_module2/pom.xml
+++ b/spec/fixtures/maven/sample_maven_junit3_multimodule_project/sample_module2/pom.xml
@@ -20,4 +20,12 @@
         </plugins>
     </build>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.vimtest.calc</groupId>
+            <artifactId>sample_module</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/pom.xml
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/pom.xml
@@ -9,6 +9,7 @@
     <version>1.0-SNAPSHOT</version>
     <modules>
         <module>sample_module</module>
+        <module>sample_module2</module>
     </modules>
     <name>sample_maven_project</name>
     <url>http://maven.apache.org</url>

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/pom.xml
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>vimtest</artifactId>
+        <groupId>org.vimtest</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sample_module2</artifactId>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <includes>
+                                <include>**/IT*.java</include>
+                                <include>**/*IT.java</include>
+                                <include>**/*ITCase.java</include>
+                            </includes>
+                        </configuration>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.vimtest</groupId>
+            <artifactId>sample_module</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/main/java/org/vimtest/App.java
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/main/java/org/vimtest/App.java
@@ -1,0 +1,19 @@
+package org.vimtest;
+
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+    }
+
+    public Integer add(Integer a, Integer b)
+    {
+        return a + b;
+    }
+}

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppIT.java
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppIT.java
@@ -1,0 +1,26 @@
+package org.vimtest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+
+/**
+ * TestAppIT
+ */
+public class AppIT {
+
+    @Test
+    public void test_integration_it() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration_it2() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration_it3() {
+        Assertions.assertEquals(true, true);
+    }
+}

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppITCase.java
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppITCase.java
@@ -1,0 +1,26 @@
+package org.vimtest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+
+/**
+ * TestAppIT
+ */
+public class AppITCase {
+
+    @Test
+    public void test_integration_it_case() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration_it_case2() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration_it_case3() {
+        Assertions.assertEquals(true, true);
+    }
+}

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppTestIntegration.java
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/AppTestIntegration.java
@@ -1,0 +1,26 @@
+package org.vimtest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+
+/**
+ * TestAppIT
+ */
+public class AppTestIntegration {
+
+    @Test
+    public void test_integration() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration2() {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_integration3() {
+        Assertions.assertEquals(true, true);
+    }
+}

--- a/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/TestApp.java
+++ b/spec/fixtures/maven/sample_maven_junit5_multimodule_project/sample_module2/src/test/java/org/vimtest/TestApp.java
@@ -1,0 +1,42 @@
+package org.vimtest;
+
+import org.vimtest.App;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Assertions;
+
+
+public class TestApp 
+{
+    @Test void test_testdecorator_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test public void test_testdecorator_public_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    void test_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Test
+    public void test_public_void()
+    {
+        Assertions.assertEquals(true, true);
+    }
+
+    @Nested
+    class Test_NestedTestClass
+    {
+        @Test
+        public void test_nested_test()
+        {
+            Assertions.assertEquals(true, true);
+        }
+    }
+}

--- a/spec/maventest_spec.vim
+++ b/spec/maventest_spec.vim
@@ -97,63 +97,63 @@ describe "Maven Junit3 multimodule tests"
     view sample_module/src/test/java/org/vimtest/math/TestMath.java
     TestFile
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.TestMath\* -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.TestMath\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs file tests (filename matches *Test.java)"
     view sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestFile
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTest\* -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTest\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs file tests (filename matches *Tests.java)"
     view sample_module/src/test/java/org/vimtest/math/MathTests.java
     TestFile
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTests\* -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTests\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs file tests (filename matches *TestCase.java)"
     view sample_module/src/test/java/org/vimtest/math/MathTestCase.java
     TestFile
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTestCase\* -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.math.MathTestCase\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs file tests with user provided options"
     view sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestFile -f pom.xml
 
-    Expect g:test#last_command == 'mvn -f pom.xml test -Dtest=org.vimtest.math.MathTest\* -pl sample_module'
+    Expect g:test#last_command == 'mvn -f pom.xml test -Dtest=org.vimtest.math.MathTest\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs nearest tests"
     view +37 sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestNearest
 
-    Expect g:test#last_command == "mvn test -Dtest=org.vimtest.math.MathTest\\#testFailedAdd -pl sample_module"
+    Expect g:test#last_command == "mvn test -Dtest=org.vimtest.math.MathTest\\#testFailedAdd -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module"
   end
 
   it "runs a suite"
     view sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestSuite
 
-    Expect g:test#last_command == 'mvn test -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs a test suite with user provided options"
     view sample_module/src/test/java/org/vimtest/math/MathTest.java
     TestSuite -X -f pom.xml -DcustomProperty=5
 
-    Expect g:test#last_command == 'mvn -X -f pom.xml -DcustomProperty=5 test -pl sample_module'
+    Expect g:test#last_command == 'mvn -X -f pom.xml -DcustomProperty=5 test -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "runs a suite from sub_multimodule/submodule2"
     view sub_multimodule/submoduleA/src/test/java/org/vimtest/math/MathTest.java
     TestSuite
 
-    Expect g:test#last_command == 'mvn test -pl sub_multimodule/submoduleA'
+    Expect g:test#last_command == 'mvn test -Dsurefire.failIfNoSpecifiedTests=false -am -pl sub_multimodule/submoduleA'
   end
 
 
@@ -287,42 +287,42 @@ describe "Maven Junit5 multimodule tests"
     view +14 sample_module/src/test/java/org/vimtest/TestApp.java
     TestFile
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\* -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest - @Test void func()"
     view +12 sample_module/src/test/java/org/vimtest/TestApp.java
     TestNearest
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_testdecorator_void -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_testdecorator_void -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest - @Test public void func()"
     view +17 sample_module/src/test/java/org/vimtest/TestApp.java
     TestNearest
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_testdecorator_public_void -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_testdecorator_public_void -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest - void func()"
     view +22 sample_module/src/test/java/org/vimtest/TestApp.java
     TestNearest
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_void -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_void -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest - public void func()"
     view +30 sample_module/src/test/java/org/vimtest/TestApp.java
     TestNearest
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_public_void -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\#test_public_void -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest - nested test()"
     view +39 sample_module/src/test/java/org/vimtest/TestApp.java
     TestNearest
 
-    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\$Test_NestedTestClass\#test_nested_test -pl sample_module'
+    Expect g:test#last_command == 'mvn test -Dtest=org.vimtest.TestApp\$Test_NestedTestClass\#test_nested_test -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
 end
@@ -367,7 +367,7 @@ describe "Integration tests in multimodule"
     view +14 sample_module/src/test/java/org/vimtest/TestApp.java
     IntegrationTest
 
-    Expect g:test#last_command == 'mvn verify -Dit.test=TestApp\* -pl sample_module'
+    Expect g:test#last_command == 'mvn verify -Dit.test=TestApp\* -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest runs with verify fully qualified classname and method name, based on filename sufix *IT"
@@ -375,68 +375,68 @@ describe "Integration tests in multimodule"
     view +13 sample_module/src/test/java/org/vimtest/AppIT.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . " -Dit.test=org.vimtest.AppIT\\#test_integration_it -pl sample_module"
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . " -Dit.test=org.vimtest.AppIT\\#test_integration_it -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module"
 
     view +18 sample_module/src/test/java/org/vimtest/AppIT.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\#test_integration_it2 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\#test_integration_it2 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +23 sample_module/src/test/java/org/vimtest/AppIT.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\#test_integration_it3 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\#test_integration_it3 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest runs with verify fully qualified classname and method name, based on filename sufix *ITCase.java"
     view +13 sample_module/src/test/java/org/vimtest/AppITCase.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +18 sample_module/src/test/java/org/vimtest/AppITCase.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case2 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case2 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +23 sample_module/src/test/java/org/vimtest/AppITCase.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case3 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\#test_integration_it_case3 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestNearest runs with verify fully qualified classname and method name, based on filename sufix *Integration.java"
     view +13 sample_module/src/test/java/org/vimtest/AppTestIntegration.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +18 sample_module/src/test/java/org/vimtest/AppTestIntegration.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration2 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration2 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +23 sample_module/src/test/java/org/vimtest/AppTestIntegration.java
 
     TestNearest
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration3 -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\#test_integration3 -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
   end
 
   it "TestFile runs with verify fully qualified classname, based on filename sufix *IT|Integration|ITCase.java"
     view +13 sample_module/src/test/java/org/vimtest/AppIT.java
 
     TestFile
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\* -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppIT\* -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +13 sample_module/src/test/java/org/vimtest/AppITCase.java
 
     TestFile
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\* -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppITCase\* -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
     view +13 sample_module/src/test/java/org/vimtest/AppTestIntegration.java
 
     TestFile
-    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\* -pl sample_module'
+    Expect g:test#last_command == t:expected_it_nearest_file_prefix . ' -Dit.test=org.vimtest.AppTestIntegration\* -Dfailsafe.failIfNoSpecifiedTests=false -am -pl sample_module'
 
   end
 end


### PR DESCRIPTION
Running a single test or test suite in a multimodule Maven project doesn't work when the test is in a submodule `B` that depends on another submodule `A`. In these cases, we need to add:

- `-am` so Maven (re)builds module `A` as well as `B`, if necessary
- `-Dsurefire.failIfNoSpecifiedTests=false` so the build doesn't fail when the specified test from module `B` doesn't exist in `A` (only in case of running unit tests with surefire)
- `-Dfailsafe.failIfNoSpecifiedTests=false` so the build doesn't fail when the specified test from module `B` doesn't exist in `A` (only in case of running integration tests with failsafe)

If the test is in `A`, these parameters aren't necessary, but it doesn't matter if they're there. If the test is in `B`, Maven fails because it tries to find the test in `A` and can't find it there. So we'll just add the parameters in all multi-module cases.

I've added a dependent module in both `sample_maven_junit3_multimodule_project` and `sample_maven_junit5_multimodule_project`, even if it's not strictly necessary for `vim-test`'s tests, so the underlying issue can be reproduced.

Here's the error in question:

```
$ mvn test -Dtest=org.vimtest.math.# -pl sample_module2

[INFO] Scanning for projects...
[INFO] 
[INFO] ------------------< org.vimtest.calc:sample_module2 >-------------------
[INFO] Building sample_module2 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for org.vimtest.calc:sample_module:jar:1.0-SNAPSHOT is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.251 s
[INFO] Finished at: 2024-12-18T15:56:26+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project sample_module2: Could not resolve dependencies for project org.vimtest.calc:sample_module2:jar:1.0-SNAPSHOT
[ERROR] dependency: org.vimtest.calc:sample_module:jar:1.0-SNAPSHOT (compile)
[ERROR] 	Could not find artifact org.vimtest.calc:sample_module:jar:1.0-SNAPSHOT
[ERROR] 
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

With this command it succeeds:
```
$ mvn test -Dtest=org.vimtest.math.# -Dsurefire.failIfNoSpecifiedTests=false -am -pl sample_module2
```
---
Make sure these boxes are checked before submitting your pull request:

- [X] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [X] Update the Vim documentation in `doc/test.txt`
