### PR TITLE
Fix cargo test handling of `src/bin` files

### DIFF
--- a/spec/cargotest_spec.vim
+++ b/spec/cargotest_spec.vim
@@ -12,7 +12,7 @@ describe "Cargo"
     cd -
   end
 
-  it "runs file tests"
+  it "runs lib file tests"
     view src/lib.rs
     TestFile
     Expect g:test#last_command == 'cargo test '''''
@@ -32,6 +32,20 @@ describe "Cargo"
     view src/too/nested.rs
     TestFile
     Expect g:test#last_command == 'cargo test ''too::nested::'''
+  end
+
+  it "runs bin file tests"
+    view src/bin/somebin.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test --bin somebin '''''
+
+    view src/bin/nestedbin/main.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test --bin nestedbin '''''
+
+    view src/bin/nestedbin/somemod.rs
+    TestFile
+    Expect g:test#last_command == 'cargo test --bin nestedbin ''somemod::'''
   end
 
   it "runs nearest test on lib.rs"
@@ -115,6 +129,32 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test ''too::nested::tests::second_test'' -- --exact'
   end
 
+  it "runs nearest test on bins"
+    view +7 src/bin/somebin.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin somebin ''tests::first_test'' -- --exact'
+
+    view +11 src/bin/somebin.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin somebin ''tests::second_test'' -- --exact'
+
+    view +9 src/bin/nestedbin/main.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin nestedbin ''tests::first_test'' -- --exact'
+
+    view +13 src/bin/nestedbin/main.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin nestedbin ''tests::second_test'' -- --exact'
+
+    view +4 src/bin/nestedbin/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin nestedbin ''somemod::tests::first_test'' -- --exact'
+
+    view +8 src/bin/nestedbin/somemod.rs
+    TestNearest
+    Expect g:test#last_command == 'cargo test --bin nestedbin ''somemod::tests::second_test'' -- --exact'
+  end
+
   it "runs test suites"
     view src/lib.rs
     TestSuite
@@ -129,6 +169,18 @@ describe "Cargo"
     Expect g:test#last_command == 'cargo test'
 
     view src/too/nested.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/bin/somebin.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/bin/nestedbin/main.rs
+    TestSuite
+    Expect g:test#last_command == 'cargo test'
+
+    view src/bin/nestedbin/somemod.rs
     TestSuite
     Expect g:test#last_command == 'cargo test'
   end

--- a/spec/fixtures/cargo/crate/src/bin/nestedbin/main.rs
+++ b/spec/fixtures/cargo/crate/src/bin/nestedbin/main.rs
@@ -1,0 +1,15 @@
+mod somemod;
+
+fn main() {
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn first_test() {
+    }
+
+    #[test]
+    fn second_test() {
+    }
+}

--- a/spec/fixtures/cargo/crate/src/bin/nestedbin/somemod.rs
+++ b/spec/fixtures/cargo/crate/src/bin/nestedbin/somemod.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn first_test() {
+    }
+
+    #[test]
+    fn second_test() {
+    }
+}

--- a/spec/fixtures/cargo/crate/src/bin/somebin.rs
+++ b/spec/fixtures/cargo/crate/src/bin/somebin.rs
@@ -1,0 +1,13 @@
+fn main() {
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn first_test() {
+    }
+
+    #[test]
+    fn second_test() {
+    }
+}


### PR DESCRIPTION
This is a special directory for projects that author multiple binaries. When focusing tests in these directories, `bin::` should be omitted from the module path, and the `--bin` argument should be set to the appropriate binary name (derived from the path).

See:
https://doc.rust-lang.org/cargo/reference/cargo-targets.html#binaries

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
