### PR TITLE
Unload no name buffers in s:neovim_reopen_term

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -90,7 +90,10 @@ endfunction
 function! s:neovim_reopen_term(bufnr) abort
   let l:current_window = win_getid()
   let term_position = get(g:, 'test#neovim#term_position', 'botright')
-  execute term_position . ' new | buffer ' . a:bufnr
+  execute term_position . ' new'
+  " we need to unload the no name buffer we just created
+  let l:current_buffer = bufnr("%")
+  execute 'buffer ' . a:bufnr . ' | bunload ' . l:current_buffer
 
   let l:new_window = win_getid()
   call win_gotoid(l:current_window)


### PR DESCRIPTION
`[No Name]` buffers are created when we call `s:neovim_reopen_term()` as we call `new` before switching to the terminal buffer. This change calls `bunload` to unload the temporary no name buffer so we don't pollute the buffer list with no name buffers.

Make sure these boxes are checked before submitting your pull request:

- [ ] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
