### PR TITLE
Add neovim_sticky use_existing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,10 @@ the previous one has finished, it will either wait or fail to run at all.
 You can customize this behavior with the following options:
 
 ```vim
-let g:test#neovim_sticky#kill_previous = 1  " Try to abort previous run
 let g:test#preserve_screen = 0  " Clear screen from previous run
-let test#neovim_sticky#reopen_window = 1 " Reopen terminal split if not visible
+let g:test#neovim_sticky#kill_previous = 1  " Try to abort previous run
+let g:test#neovim_sticky#reopen_window = 1  " Reopen terminal split if not visible
+let g:test#neovim_sticky#use_existing = 1  " Use manually opened terminal, if exists
 ```
 
 ### Kitty strategy setup

--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -111,10 +111,14 @@ function! test#strategy#neovim_sticky(cmd) abort
   let l:buffers = getbufinfo({ 'buflisted': 1 })
     \ ->filter({i, v -> has_key(v.variables, l:tag)})
 
+  if !len(l:buffers) && get(g:, 'test#neovim_sticky#use_existing', 0)
+    let l:buffers = getbufinfo({ 'buflisted': 1 })
+      \ ->filter({i, v -> has_key(v.variables, 'terminal_job_id')})
+  end
+
   if len(l:buffers) == 0
     let l:current_window = win_getid()
     call s:neovim_new_term(&shell)
-    let b:[l:tag] = 1
     let l:buffers = getbufinfo(bufnr())
     call win_gotoid(l:current_window)
   else
@@ -125,6 +129,7 @@ function! test#strategy#neovim_sticky(cmd) abort
       let l:cmd = [""] + l:cmd
     endif
   endif
+  call setbufvar(l:buffers[0].bufnr, l:tag, 1)
 
   let l:win = win_findbuf(l:buffers[0].bufnr)
   if !len(l:win) && get(g:, 'test#neovim_sticky#reopen_window', 0)

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -700,7 +700,12 @@ scheduling a new one, use:
 To have the Neovim sticky strategy open an existing terminal in a new split
 when it is not currently visible, use:
 >
-    let test#neovim_sticky#reopen_window = 1
+  let g:test#neovim_sticky#reopen_window = 1
+
+To have the Neovim sticky strategy use an existing terminal it did not open
+on its own, if such exists, use:
+
+  let g:test#neovim_sticky#use_existing = 1
 <
 You may find yourself specifying certain options for your test runners in
 certain situations. You can configure your preferred options with


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

Resolves #836 

Small reformatting of previous options docs' for more consistent look.