### PR TITLE
Add `uv` support for python runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,8 +499,9 @@ and will use `poetry run pytest` if it detects a `poetry.lock`. The pyunit and n
 runner supports [pipenv](https://github.com/pypa/pipenv) as well and will
 respectively use `pipenv run python -m unittest` or `pipenv run python -m nosetests`
 if there is a `Pipfile`. It also supports [pdm](https://pdm.fming.dev/) as well and
-will use `poetry run pytest` if there is a `pdm.lock` file.
-
+will use `poetry run pytest` if there is a `pdm.lock` file. As well as [uv](https://github.com/astral-sh/uv) and will use `uv run pytest` if there is `uv.lock` file.
+All runners except `djangotest` support uv and will use `uv run` if there's a
+`uv.lock` file.
 #### Java
 
 For the same reason as Python, runner detection works the same for Java. To

--- a/autoload/test/python/mamba.vim
+++ b/autoload/test/python/mamba.vim
@@ -46,6 +46,8 @@ function! test#python#mamba#executable() abort
     let pipenv_prefix = "poetry run "
   elseif filereadable("pdm.lock")
     let pipenv_prefix = "pdm run "
+  elseif filereadable("uv.lock")
+    let pipenv_prefix = "uv run "
   endif
 
   return pipenv_prefix . "mamba"

--- a/autoload/test/python/nose.vim
+++ b/autoload/test/python/nose.vim
@@ -38,6 +38,8 @@ function! test#python#nose#executable() abort
     let pipenv_prefix = "pipenv run "
   elseif filereadable("poetry.lock")
     let pipenv_prefix = "poetry run "
+  elseif filereadable("uv.lock")
+    let pipenv_prefix = "uv run "
   endif
 
   return pipenv_prefix . "nosetests"

--- a/autoload/test/python/pytest.vim
+++ b/autoload/test/python/pytest.vim
@@ -57,6 +57,8 @@ function! test#python#pytest#executable() abort
     let pipenv_prefix = "poetry run "
   elseif filereadable("pdm.lock")
     let pipenv_prefix = "pdm run "
+  elseif filereadable("uv.lock")
+    let pipenv_prefix = "uv run "
   else
     let pipenv_prefix = test#python#executable() . " -m "
   endif

--- a/autoload/test/python/pyunit.vim
+++ b/autoload/test/python/pyunit.vim
@@ -37,6 +37,8 @@ function! test#python#pyunit#executable() abort
 
   if filereadable("Pipfile")
     let pipenv_prefix = "pipenv run "
+  elseif filereadable("uv.lock")
+    let pipenv_prefix = "uv run "
   endif
 
   return pipenv_prefix . test#python#executable() . ' -m unittest'

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -820,7 +820,8 @@ it will use `pipenv run pytest` instead of just `python -m pytest`. They also su
 and will use `poetry run pytest` if it detects a `poetry.lock`. The pyunit and nose runner
 supports pipenv as well and will respectively use `pipenv run python -m unittest` or
 `pipenv run python -m nosetests` if there is a `Pipfile`. It also supports pdm as well and will
-use `poetry run pytest` if there is a `pdm.lock` file.
+use `poetry run pytest` if there is a `pdm.lock` file. All runners except
+`djangotest` support uv and will use `uv run` if there is a `uv.lock` file.
 
 PROJECTIONIST INTEGRATION                       *test-projectionist*
 

--- a/spec/mamba_uv_spec.vim
+++ b/spec/mamba_uv_spec.vim
@@ -1,0 +1,22 @@
+source spec/support/helpers.vim
+
+describe "Mamba with uv"
+  before
+    let g:test#python#runner = 'mamba'
+    cd spec/fixtures/mamba
+    !touch uv.lock
+  end
+
+  after
+    !rm uv.lock
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view normal_spec.py
+    TestFile
+
+    Expect g:test#last_command == 'uv run mamba normal_spec.py'
+  end
+end

--- a/spec/nose_uv_spec.vim
+++ b/spec/nose_uv_spec.vim
@@ -1,0 +1,24 @@
+source spec/support/helpers.vim
+
+describe "Nose with uv"
+
+  before
+    let g:test#python#runner = 'nose'
+    cd spec/fixtures/nose
+    !touch uv.lock
+  end
+
+  after
+    !rm uv.lock
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view test_class.py
+    TestFile
+
+    Expect g:test#last_command == 'uv run nosetests --doctest-tests test_class.py'
+  end
+
+end

--- a/spec/pytest_uv_spec.vim
+++ b/spec/pytest_uv_spec.vim
@@ -1,0 +1,24 @@
+source spec/support/helpers.vim
+
+describe "PyTest with uv"
+
+  before
+    let g:test#python#runner = 'pytest'
+    cd spec/fixtures/pytest
+    !touch uv.lock
+  end
+
+  after
+    !rm uv.lock
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view test_class.py
+    TestFile
+
+    Expect g:test#last_command == 'uv run pytest test_class.py'
+  end
+
+end

--- a/spec/pyunit_uv_spec.vim
+++ b/spec/pyunit_uv_spec.vim
@@ -1,0 +1,24 @@
+source spec/support/helpers.vim
+
+describe "PyUnit with uv"
+
+  before
+    let g:test#python#runner = 'pyunit'
+    cd spec/fixtures/pytest
+    !touch uv.lock
+  end
+
+  after
+    !rm uv.lock
+    call Teardown()
+    cd -
+  end
+
+  it "runs file tests"
+    view test_class.py
+    TestFile
+
+    Expect g:test#last_command == 'uv run python3 -m unittest test_class'
+  end
+
+end


### PR DESCRIPTION
Fixes #840 
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

I mostly mimicked https://github.com/vim-test/vim-test/pull/538, but let me know if I need to tweak something.

P.S. I went by grepping `pipenv` and added `uv` in the same places, and I see `pipenv` is supported for more runners than just `pytest` and `djangotest`, or so it seems at least 😅 
P.P.S off-topic, but just wanted to say that it was a pleasure finding this plugin, not just because it's the first one that works, but also because you're really supportive of contributors, so thank you!
