### PR TITLE
escape brackets in pathnames when running jest

### DIFF
--- a/autoload/test/javascript/jest.vim
+++ b/autoload/test/javascript/jest.vim
@@ -13,14 +13,15 @@ function! test#javascript#jest#test_file(file) abort
 endfunction
 
 function! test#javascript#jest#build_position(type, position) abort
+  let file = escape(a:position['file'], '()[]')
   if a:type ==# 'nearest'
     let name = s:nearest_test(a:position)
     if !empty(name)
       let name = '-t '.shellescape(escape(name, '()[]'), 1)
     endif
-    return ['--runTestsByPath', name, '--', a:position['file']]
+    return ['--runTestsByPath', name, '--', file]
   elseif a:type ==# 'file'
-    return ['--runTestsByPath', '--', a:position['file']]
+    return ['--runTestsByPath', '--', file]
   else
     return []
   endif

--- a/spec/jest_spec.vim
+++ b/spec/jest_spec.vim
@@ -117,10 +117,15 @@ describe "Jest"
   end
 
   it "runs file tests"
-    view __tests__/normal-test.js
+    view +1 __tests__/normal-test.js
     TestFile
 
     Expect g:test#last_command == 'jest --runTestsByPath -- __tests__/normal-test.js'
+
+    view +2 __tests__/(folder)/normal-test.js
+    TestFile
+
+    Expect g:test#last_command == 'jest --runTestsByPath -- __tests__/\(folder\)/normal-test.js'
   end
 
   it "runs test suites"


### PR DESCRIPTION
Escapes brackets in file/path names when running tests using Jest. Use case is for developers working on NextJS codebases where bracketed folder names are used to group modules.

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
