### PR TITLE
Remove useless echo of nearest test info for PHPUnit

### DIFF
--- a/autoload/test/php/phpunit.vim
+++ b/autoload/test/php/phpunit.vim
@@ -69,7 +69,6 @@ function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#php#phpunit#test_patterns)
 
   " If we found the '@test' docblock
-  echomsg name
   if !empty(name['test']) && ('@test' == name['test'][0] || '#' == name['test'][0][0])
     " Search forward for the first declared public method
     let name = test#base#nearest_test_in_lines(


### PR DESCRIPTION
The information for the nearest PHPUnit test is printed and triggers a hit-enter prompt in some cases. I don't see the value of this being printed apart for debugging purposes.