### PR TITLE
Add Nearest support to vim-themis (vimspec style)

### DIFF
--- a/autoload/test/viml/themis.vim
+++ b/autoload/test/viml/themis.vim
@@ -17,8 +17,19 @@ function! test#viml#themis#test_file(file) abort
   return v:false
 endfunction
 
+" Available granularities:
+" - Nearest: 'vimspec' syntax only
+" - Suite:   No
+" - Class:   No
 function! test#viml#themis#build_position(type, position) abort
-  if a:type == 'nearest' || a:type == 'file'
+  if a:type ==# 'nearest'
+    let target = s:nearest_test(a:position)
+    if !empty(target)
+      return [a:position['file'], '--target', target]
+    else
+      return [a:position['file']]
+    endif
+  elseif a:type ==# 'file'
     return [a:position['file']]
   else
     return []
@@ -31,4 +42,42 @@ endfunction
 
 function! test#viml#themis#executable() abort
   return 'themis'
+endfunction
+
+let s:spec_patterns = {
+  \ 'test': [
+    \ '\v^\s*[iI]t\s+(.+)',
+  \],
+  \ 'namespace': [
+    \ '\v^\s*%([Dd]escribe|[Cc]ontext)\s+(\S.*)',
+  \],
+\}
+
+function! s:nearest_test(position) abort
+  let syntax = s:syntax(a:position['file'])
+  let target = ''
+
+  if syntax ==# 'vimspec'
+    let name = test#base#nearest_test(a:position, s:spec_patterns)
+
+    if !empty(name['test'])
+      let target = shellescape(name['test'][0])
+    endif
+  endif
+
+  return target
+endfunction
+
+function! s:syntax(file) abort
+  " themis-style-basic
+  if a:file =~# '\.vim$'
+    return 'basic'
+  endif
+
+  " themis-style-vimspec
+  if a:file =~# '\.vimspec$'
+    return 'vimspec'
+  endif
+
+  return ''
 endfunction

--- a/spec/fixtures/themis/math.vimspec
+++ b/spec/fixtures/themis/math.vimspec
@@ -6,6 +6,10 @@ Describe math
     It asserts 1 plus 1 equals 2
       Assert Equals(1 + 1, 2)
     end
+
+    it doesn't "break" on ➕`?
+      Skip line
+    end
   end
 
   Context subtraction

--- a/spec/themis_spec.vim
+++ b/spec/themis_spec.vim
@@ -49,6 +49,18 @@ describe "Themis"
       messages
 
       Expect g:test#last_command == 'themis math.vimspec'
+
+      view +7 math.vimspec
+      TestNearest
+      messages
+
+      Expect g:test#last_command == "themis math.vimspec --target 'asserts 1 plus 1 equals 2'"
+
+      view +11 math.vimspec
+      TestNearest
+      messages
+
+      Expect g:test#last_command == "themis math.vimspec --target " . shellescape("doesn't \"break\" on ➕`?")
     end
 
     it "runs file tests"


### PR DESCRIPTION
Themis can use `--target pattern` to filter tests, which can be used as the Nearest position.

This PR only handles "vimspec" style, because in "basic" style (where a test is a vim function) it is unreliable to identify tests by merely pattern searching.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in doc/test.txt

(No need to update README and documentation)