### PR TITLE
Allow to disable prompt_for_unsaved_changes by set it to 0

### DIFF
--- a/autoload/test.vim
+++ b/autoload/test.vim
@@ -166,19 +166,19 @@ function! s:alternate_file() abort
 endfunction
 
 function! s:before_run() abort
-  let modified_buffers = len(getbufinfo({'bufmodified': 1}))
   if &autowrite || &autowriteall
     silent! wall
-
-  elseif exists('g:test#prompt_for_unsaved_changes') && l:modified_buffers
-    let answer = confirm(
-        \ "Warning: you have unsaved changes",
-        \ "&write\nwrite &all\n&continue", 3)
-
-    if l:answer == 1
-      write
-    elseif l:answer == 2
-      wall
+  elseif get(g:, 'test#prompt_for_unsaved_changes', 0)
+    let modified_buffers = len(getbufinfo({'bufmodified': 1}))
+    if l:modified_buffers
+      let answer = confirm(
+            \ "Warning: you have unsaved changes",
+            \ "&write\nwrite &all\n&continue", 3)
+      if l:answer == 1
+        write
+      elseif l:answer == 2
+        wall
+      endif
     endif
   endif
 


### PR DESCRIPTION
Most other `let g:test#xxx = 1` options behave as boolean value (can be turned off by set to `0`), whereas `prompt_for_unsaved_changes` is enabled whenever the variable exist.

The doc didn't clarify what a `0` should do. Make it consistent with others should be better.

This PR also avoid unnecessary modified buffer checking when the feature is turned off.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
