### PR TITLE
Ensure Pest supports running normal PHPUnit-style tests

### DIFF
--- a/autoload/test/php/pest.vim
+++ b/autoload/test/php/pest.vim
@@ -5,9 +5,19 @@ endif
 if !exists('g:test#php#pest#test_patterns')
   " Description for the tests:
   " https://pestphp.com/docs/writing-tests/
-  " Look for a function call that starts with "it" or "test" or "scenario"
+  " 1. Look for a function call that starts with "it" or "test" or "scenario"
+  " 2: Look for a public method which name starts with "test"
+  " 3: Look for a phpdoc tag "@test" (on a line by itself)
+  " 4: Look for a phpdoc block on one line containg the "@test" tag
+  " 5: Look for an attribute "#[Test]" or "#[Test," (on a line by itself)
   let g:test#php#pest#test_patterns = {
-    \ 'test': ['\v^\s*%(it|test|scenario)[(]%("|'')(.*)%("|'')'],
+    \ 'test': [
+      \ '\v^\s*%(it|test|scenario)[(]%("|'')(.*)%("|'')',
+      \ '\v^\s*public function (test\w+)\(',
+      \ '\v^\s*\*\s*(\@test)',
+      \ '\v^\s*\/\*\*\s*(\@test)\s*\*\/',
+      \ '\v^\s*(#\[\s*Test\s*[,\]])',
+    \ ],
     \ 'namespace': [],
   \}
 endif
@@ -55,6 +65,17 @@ endfunction
 function! s:nearest_test(position) abort
   " Search backward for the first method starting with 'it' or 'test'
   let name = test#base#nearest_test(a:position, g:test#php#pest#test_patterns)
+
+  " If we found the '@test' docblock
+  if !empty(name['test']) && ('@test' == name['test'][0] || '#' == name['test'][0][0])
+    " Search forward for the first declared public method
+    let name = test#base#nearest_test_in_lines(
+      \ a:position['file'],
+      \ name['test_line'],
+      \ a:position['line'],
+      \ g:test#php#patterns
+    \ )
+  endif
 
   return join(name['test'])
 endfunction

--- a/spec/fixtures/pest/NormalTest.php
+++ b/spec/fixtures/pest/NormalTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit_Framework_TestCase;
+
+class NormalTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function should_add_two_numbers()
+    {
+        $this->assertEquals(2, 1 + 1);
+    }
+
+    /**
+     * @test
+     */
+    public function should_subtract_two_numbers()
+    {
+        $this->assertEquals(2, 4 - 2);
+    }
+
+    public function additionProvider()
+    {
+        return [
+            [2, 4, 6],
+            [4, 2, 6],
+        ];
+    }
+
+    /**
+     * @dataProvider additionProvider
+     *
+     * @test
+     */
+    public function should_add_to_expected_value($a, $b, $expected)
+    {
+        $this->assertEquals($expected, $a + $b);
+    }
+
+    /**
+     * @test
+     */
+    public function a_test_marked_with_test_annotation()
+    {
+        $this->assertEquals(2, 4 - 21);
+    }
+
+    /**
+     * Possible comments
+     *
+     * @someOtherAnnotation
+     *
+     * @test
+     *
+     * @param foo bar
+     */
+    public function a_test_marked_with_test_annotation_and_crazy_docblock()
+    {
+        $this->assertEquals(2, 4 - 21);
+    }
+
+    /**
+     * @test
+     */
+    public function with_an_anonymous_class()
+    {
+        $anonymousClass = new class
+        {
+            public function foo(): void {}
+        };
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @test
+     */
+    public function a_test_maked_with_test_annotation_and_with_an_anonymous_class()
+    {
+        $anonymousClass = new class
+        {
+            public function foo(): void {}
+        };
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function a_test_marked_with_test_annotation_on_one_line()
+    {
+        $this->assertEquals(2, 4 - 21);
+    }
+
+    #[Test]
+    public function aTestMarkedWithTestAttributeOnOneLine()
+    {
+        $this->assertEquals(2, 4 - 21);
+    }
+
+    #[Test,TestWith([2, 4 - 21])]
+    public function aTestMarkedWithTestAttributeInGroupOnOneLine(int $expected, int $value)
+    {
+        $this->assertEquals($expected, $value);
+    }
+
+    #[
+        Test,
+        TestWith([2, 4 - 21]),
+    ]
+    public function aTestMarkedWithTestAttributeInGroupOnMultipleLines(int $expected, int $value)
+    {
+        $this->assertEquals($expected, $value);
+    }
+}

--- a/spec/pest_spec.vim
+++ b/spec/pest_spec.vim
@@ -18,7 +18,14 @@ describe "Pest"
     Expect g:test#last_command == 'pest --colors PestTest.php'
   end
 
-  it "runs nearest tests"
+  it "runs file tests on normal tests"
+    view NormalTest.php
+    TestFile
+
+    Expect g:test#last_command == 'pest --colors NormalTest.php'
+  end
+
+  it "runs tests"
     view +1 PestTest.php
     TestNearest
 
@@ -40,8 +47,82 @@ describe "Pest"
     Expect g:test#last_command == "pest --colors --filter 'bdd flavour' PestTest.php"
   end
 
+  it  "runs nearest test marked with @test annotation"
+    view +40 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMarkedWithTestAnnotation' NormalTest.php"
+
+    view +50 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMarkedWithTestAnnotationAndCrazyDocblock' NormalTest.php"
+  end
+
+  it  "runs nearest test containing an anonymous class"
+    view +61 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'testWithAnAnonymousClass' NormalTest.php"
+
+    view +76 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMakedWithTestAnnotationAndWithAnAnonymousClass' NormalTest.php"
+  end
+
+  it "runs nearest tests on normal test"
+    view +1 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors NormalTest.php"
+
+    view +9 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'testShouldAddTwoNumbers' NormalTest.php"
+
+    view +14 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'testShouldSubtractTwoNumbers' NormalTest.php"
+
+    view +30 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'testShouldAddToExpectedValue' NormalTest.php"
+  end
+
+  it "runs nearest test with a one line @test annotation"
+    view +83 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMarkedWithTestAnnotationOnOneLine' NormalTest.php"
+  end
+
+  it "runs nearest test with a one line #[Test] attribute"
+    view +87 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMarkedWithTestAttributeOnOneLine' NormalTest.php"
+  end
+
+  it "runs nearest test with a one line #[Test] attribute in a group"
+    view +93 NormalTest.php
+    TestNearest
+
+    Expect g:test#last_command == "pest --colors --filter 'aTestMarkedWithTestAttributeInGroupOnOneLine' NormalTest.php"
+  end
+
   it "runs test suites"
     view PestTest.php
+    TestSuite
+
+    Expect g:test#last_command == 'pest --colors'
+  end
+
+  it "runs test suites on normal tests"
+    view NormalTest.php
     TestSuite
 
     Expect g:test#last_command == 'pest --colors'


### PR DESCRIPTION
### Changed

- Ensure Pest plugin supports the regular PHPUnit-style for writing tests as well. This is supported by Pest itself, but the plugin is not handling it.

---

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
