### PR TITLE
Disable generic runner (.vimtest.json) by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,6 +760,12 @@ let g:test#custom_alternate_file = function('CustomAlternateFile')
 
 This is considered an advanced feature, subject to active development and further changes. It overrides the zero configuration approach, and requires you to manually configure the test runners.
 
+Enable the feature by adding this custom runner:
+
+```vim
+  let g:test#custom_runners = {'_Generic': ['VimTestJson']}
+```
+
 To provide middle ground between well-known test runners working out of the box,
 and per-user configuration, test command can also be specifying by adding a `.vimtest.json`
 file:

--- a/doc/test.txt
+++ b/doc/test.txt
@@ -862,6 +862,10 @@ OVERRIDING TEST COMMANDS                        *test-overriding-test-commands*
 This is considered an advanced feature, subject to active development and further changes.
 It overrides the zero configuration approach, and requires you to manually configure the test runners.
 
+Enable the feature by adding this custom runner:
+>
+  let g:test#custom_runners = {'_Generic': ['VimTestJson']}
+<
 To provide middle ground between well-known test runners working out of the box,
 and per-user configuration, test command can also be specifying by adding a `.vimtest.json`
 file:

--- a/plugin/test.vim
+++ b/plugin/test.vim
@@ -6,7 +6,6 @@ let g:loaded_test = 1
 let g:test#plugin_path = expand('<sfile>:p:h:h')
 
 let g:test#default_runners = {
-  \ '_Generic':   ['VimTestJson'],
   \ 'CSharp':     ['Xunit', 'DotnetTest'],
   \ 'Clojure':    ['FireplaceTest', 'LeinTest'],
   \ 'Crystal':    ['CrystalSpec'],

--- a/spec/generic_spec.vim
+++ b/spec/generic_spec.vim
@@ -8,6 +8,10 @@ function s:expect_override() abort
   Expect g:test#last_command == "echo 'override spec'"
 endfunction
 
+function s:expect_not_run() abort
+  Expect exists('g:test#last_command') to_be_false
+endfunction
+
 describe 'Generic runner'
   before
     cd spec/fixtures/generic
@@ -18,7 +22,41 @@ describe 'Generic runner'
     cd -
   end
 
-  describe 'TODO: Disabled by default'
+  describe 'Disabled by default'
+    it 'runs command from opened vimtest.json'
+      view .vimtest.json
+      for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
+        execute l:command
+        call s:expect_not_run()
+      endfor
+    end
+
+    it 'runs command from vimtest.json in same directory'
+      view readme.md
+      for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
+        execute l:command
+        call s:expect_not_run()
+      endfor
+    end
+
+    it 'runs command from vimtest.json in parent directory'
+      view nooverride/readme.md
+      TestFile
+      call s:expect_not_run()
+    end
+
+    it 'runs command from closest vimtest.json'
+      view override/readme.md
+      TestFile
+      call s:expect_not_run()
+    end
+  end
+
+  describe 'Enabled with custom_runner'
+    before
+      let g:test#custom_runners = {'_Generic': ['VimTestJson']}
+    end
+
     it 'runs command from opened vimtest.json'
       view .vimtest.json
       for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]

--- a/spec/generic_spec.vim
+++ b/spec/generic_spec.vim
@@ -18,32 +18,34 @@ describe 'Generic runner'
     cd -
   end
 
-  it 'runs command from opened vimtest.json'
-    view .vimtest.json
-    for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
-      execute l:command
+  describe 'TODO: Disabled by default'
+    it 'runs command from opened vimtest.json'
+      view .vimtest.json
+      for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
+        execute l:command
+        call s:expect_root()
+      endfor
+    end
+
+    it 'runs command from vimtest.json in same directory'
+      view readme.md
+      for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
+        execute l:command
+        call s:expect_root()
+      endfor
+    end
+
+    it 'runs command from vimtest.json in parent directory'
+      view nooverride/readme.md
+      TestFile
       call s:expect_root()
-    endfor
-  end
+    end
 
-  it 'runs command from vimtest.json in same directory'
-    view readme.md
-    for l:command in [ 'TestFile', 'TestSuite', 'TestClass', 'TestNearest' ]
-      execute l:command
-      call s:expect_root()
-    endfor
-  end
-
-  it 'runs command from vimtest.json in parent directory'
-    view nooverride/readme.md
-    TestFile
-    call s:expect_root()
-  end
-
-  it 'runs command from closest vimtest.json'
-    view override/readme.md
-    TestFile
-    call s:expect_override()
+    it 'runs command from closest vimtest.json'
+      view override/readme.md
+      TestFile
+      call s:expect_override()
+    end
   end
 end
 


### PR DESCRIPTION
Fix #852 

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
