### PR TITLE
Improve Nearest test for vim-themis (vimspec style)

### DIFF
--- a/autoload/test/viml/themis.vim
+++ b/autoload/test/viml/themis.vim
@@ -61,7 +61,10 @@ function! s:nearest_test(position) abort
     let name = test#base#nearest_test(a:position, s:spec_patterns)
 
     if !empty(name['test'])
-      let target = escape(name['test'][0], '.*~\[^$') " escape vim patterns
+      let test = name['test'][0]
+      let ns = empty(name['namespace']) ? '' : (name['namespace'][-1] . ' ')
+      let target = ns . test
+      let target = escape(target, '.*~\[^$') " escape vim patterns
       let target = shellescape(target)
     endif
   endif

--- a/autoload/test/viml/themis.vim
+++ b/autoload/test/viml/themis.vim
@@ -61,7 +61,8 @@ function! s:nearest_test(position) abort
     let name = test#base#nearest_test(a:position, s:spec_patterns)
 
     if !empty(name['test'])
-      let target = shellescape(name['test'][0])
+      let target = escape(name['test'][0], '.*~\[^$') " escape vim patterns
+      let target = shellescape(target)
     endif
   endif
 

--- a/spec/fixtures/themis/math.vimspec
+++ b/spec/fixtures/themis/math.vimspec
@@ -10,6 +10,10 @@ Describe math
     it doesn't "break" on ➕`?
       Skip line
     end
+
+    it contains vim pattern e.g., (\@<=) or .*~\[^$
+      Skip line
+    end
   end
 
   Context subtraction

--- a/spec/fixtures/themis/math.vimspec
+++ b/spec/fixtures/themis/math.vimspec
@@ -21,4 +21,8 @@ Describe math
       Assert Equals(1 - 1, 0)
     end
   end
+
+  It out of context
+    Assert Equals(1 - 1, 0)
+  End
 end

--- a/spec/themis_spec.vim
+++ b/spec/themis_spec.vim
@@ -61,6 +61,12 @@ describe "Themis"
       messages
 
       Expect g:test#last_command == "themis math.vimspec --target " . shellescape("doesn't \"break\" on ➕`?")
+
+      view +15 math.vimspec
+      TestNearest
+      messages
+
+      Expect g:test#last_command == "themis math.vimspec --target " . shellescape('addition contains vim pattern ' . escape('e.g., (\@<=) or .*~\[^$', '.*~\[^$'))
     end
 
     it "runs file tests"

--- a/spec/themis_spec.vim
+++ b/spec/themis_spec.vim
@@ -54,19 +54,25 @@ describe "Themis"
       TestNearest
       messages
 
-      Expect g:test#last_command == "themis math.vimspec --target 'asserts 1 plus 1 equals 2'"
+      Expect g:test#last_command == "themis math.vimspec --target 'addition asserts 1 plus 1 equals 2'"
 
       view +11 math.vimspec
       TestNearest
       messages
 
-      Expect g:test#last_command == "themis math.vimspec --target " . shellescape("doesn't \"break\" on ➕`?")
+      Expect g:test#last_command == "themis math.vimspec --target " . shellescape("addition doesn't \"break\" on ➕`?")
 
       view +15 math.vimspec
       TestNearest
       messages
 
       Expect g:test#last_command == "themis math.vimspec --target " . shellescape('addition contains vim pattern ' . escape('e.g., (\@<=) or .*~\[^$', '.*~\[^$'))
+
+      view +27 math.vimspec
+      TestNearest
+      messages
+
+      Expect g:test#last_command == "themis math.vimspec --target " . shellescape('math out of context')
     end
 
     it "runs file tests"


### PR DESCRIPTION
Hi, this is an enhancement after #851, details:

- Fix vim pattern special characters in test name, they should be properly escaped.
- Prepend "suite" name to test name, this helps to target a test case more accurate.

The produced test names become longer, but I believe it is acceptable, since we don't need to type it by hand.

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

(No need to update README and documentation)
