### PR TITLE
Fix and improve Playwright detection

### DIFF
--- a/autoload/test/javascript/playwright.vim
+++ b/autoload/test/javascript/playwright.vim
@@ -7,7 +7,10 @@ function! test#javascript#playwright#test_file(file) abort
       if exists('g:test#javascript#runner')
           return g:test#javascript#runner ==# 'playwright'
       else
-        return test#javascript#has_package('@playwright/test') && test#javascript#has_import(a:file, '@playwright/test')
+        return test#javascript#has_import(a:file, '@playwright/test')
+            \ || test#javascript#has_package('@playwright/test')
+            \ || filereadable('playwright.config.ts')
+            \ || filereadable('playwright.config.js')
       endif
   endif
 endfunction


### PR DESCRIPTION
Fix and improve Playwright detection to check for the presence of config, and support tests that don't directly import `@playwright/test`, which resolves #865. 