### PR TITLE
Fix triggering of autocmds when exiting terminal

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -102,7 +102,7 @@ endfunction
 
 function! test#strategy#neovim(cmd) abort
   call s:neovim_new_term(a:cmd)
-  au BufDelete <buffer> wincmd p " switch back to last window
+  au BufDelete <buffer> ++nested wincmd p " switch back to last window
   if !get(g:, 'test#neovim#start_normal', 0)
     startinsert
   endif
@@ -160,7 +160,7 @@ function! test#strategy#vimterminal(cmd) abort
   let term_position = get(g:, 'test#vim#term_position', 'botright')
   execute term_position . ' new'
   call term_start(!s:Windows() ? ['/bin/sh', '-c', a:cmd] : ['cmd.exe', '/c', a:cmd], {'curwin': 1, 'term_name': a:cmd})
-  au BufDelete <buffer> wincmd p " switch back to last window
+  au BufDelete <buffer> ++nested wincmd p " switch back to last window
   nnoremap <buffer> <Enter> :bd<CR>
   redraw
   echo "Press <Enter> to exit test runner terminal (<Ctrl-C> first if command is still running)"


### PR DESCRIPTION
When using vimterminal or neovim strategy a `BufDelete` autocmd is used to jump back to the previous window, but this is not compatible with other plugins or configuration that relies on `BufEnter` or `WinEnter` autocmds as they do not get triggered. Fix by triggering nested autocmds.

For example, this broke lightline such that it would appear that the current window was actually the previous window as the lightline update autocmds would not be triggered. There are also examples in the vim docs that would be broken without using `++nested`, e.g. `:help 'cursorcolumn'`

Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

none of the above are applicable here