### PR TITLE
Fix neovim_sticky strategy use_existing flag

### DIFF
--- a/autoload/test/strategy.vim
+++ b/autoload/test/strategy.vim
@@ -116,7 +116,7 @@ function! test#strategy#neovim_sticky(cmd) abort
 
   if !len(l:buffers) && get(g:, 'test#neovim_sticky#use_existing', 0)
     let l:buffers = getbufinfo({ 'buflisted': 1 })
-      \ ->filter({i, v -> has_key(v.variables, 'terminal_job_id')})
+      \ ->filter({i, v -> match(bufname(v.bufnr), 'term://') == 0})
   end
 
   if len(l:buffers) == 0
@@ -139,8 +139,9 @@ function! test#strategy#neovim_sticky(cmd) abort
     let l:win = [s:neovim_reopen_term(l:buffers[0].bufnr)]
   endif
 
+  let l:channel = getbufvar(l:buffers[0].bufnr, '&channel')
   " Needs explicit join to work in all shells
-  call chansend(l:buffers[0].variables.terminal_job_id, join(l:cmd, "\r"))
+  call chansend(l:channel, join(l:cmd, "\r"))
   if len(l:win) > 0
     call win_execute(l:win[0], 'normal G', 1)
   endif


### PR DESCRIPTION
Neovim deprecated `b:terminal_job_id` in version 0.9: https://neovim.io/doc/user/deprecated.html#b%3Aterminal_job_id

It appears to have been removed by 0.10. This causes the `g:test#neovim_sticky#use_existing` flag to stop working (produced in 0.11). This replaces the `terminal_job_id` with the recommended `&channel` lookup, and replaces the initial buffer lookup to find a buffer name including `term://`.

Make sure these boxes are checked before submitting your pull request: **(none applicable here, bug fix on strategy only)**

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
