### PR TITLE
Set csharp slash character for pwsh

### DIFF
--- a/autoload/test/csharp.vim
+++ b/autoload/test/csharp.vim
@@ -7,7 +7,7 @@ let g:test#csharp#patterns = {
 let s:slash = '/'
 if (has('win32') || has('win64'))
     let shell = fnamemodify(&shell, ':t')
-    if (shell ==? 'cmd.exe' || shell ==? 'powershell')
+    if (shell ==? 'cmd.exe' || shell ==? 'powershell' || shell ==? 'pwsh')
         let s:slash = '\'
     endif
 endif


### PR DESCRIPTION
Fixing the path slash character when the open source version of PowerShell is being used.

Make sure these boxes are checked before submitting your pull request: (None applicable)

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`
