### PR TITLE
fix: detect PHP Behat to use behat.yml or behat.yml.dist

### DIFF
--- a/autoload/test/php/behat.vim
+++ b/autoload/test/php/behat.vim
@@ -2,13 +2,10 @@ if !exists('g:test#php#behat#file_pattern')
   let g:test#php#behat#file_pattern = '\v\.feature$'
 endif
 
-if !exists('g:test#php#behat#bootstrap_directory')
-  let g:test#php#behat#bootstrap_directory = 'features/bootstrap/**/*.php'
-endif
-
 function! test#php#behat#test_file(file) abort
   if a:file =~# g:test#php#behat#file_pattern
-    return !empty(glob(g:test#php#behat#bootstrap_directory))
+    return filereadable('behat.yml')
+        \ || filereadable('behat.yml.dist')
   endif
 endfunction
 

--- a/spec/fixtures/behat/behat.yml
+++ b/spec/fixtures/behat/behat.yml
@@ -1,0 +1,5 @@
+default:
+  suites:
+    default:
+      paths:
+        - features

--- a/spec/fixtures/behat/features/bootstrap/FeatureContext.php
+++ b/spec/fixtures/behat/features/bootstrap/FeatureContext.php
@@ -1,7 +1,0 @@
-<?php
-
-use Behat\Behat\Context\Context;
-
-class FeatureContext extends Context {
-
-}


### PR DESCRIPTION
Resolves #816 by using `behat.yml` or `behat.yml.dist` to detect PHP Behat.
