### PR TITLE
fix: escape TestNearest for Flutter runner

### DIFF
--- a/autoload/test/dart/fluttertest.vim
+++ b/autoload/test/dart/fluttertest.vim
@@ -44,5 +44,5 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#dart#fluttertest#patterns)
-  return join(name['namespace'] + name['test'], ' ')
+  return escape(join(name['namespace'] + name['test'], ' '), '#')
 endfunction

--- a/spec/fixtures/fluttertest/escape_test.dart
+++ b/spec/fixtures/fluttertest/escape_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Myclass', () {
+    group('#myMethod', () {
+      test('assert true', () {
+        expect(true, true);
+      });
+    });
+  });
+}

--- a/spec/fluttertest_spec.vim
+++ b/spec/fluttertest_spec.vim
@@ -47,6 +47,11 @@ describe "FlutterTest"
     TestNearest
 
     Expect g:test#last_command == 'flutter test --plain-name "MyWidget a ''b''" widgets_test.dart'
+
+    view +6 escape_test.dart
+    TestNearest
+
+    Expect g:test#last_command == 'flutter test --plain-name ''Myclass #myMethod assert true'' escape_test.dart'
   end
 
   it "runs test suites"


### PR DESCRIPTION
Resolves #583.

- [x] Add fixtures and spec when implementing or updating a test runner
- [ ] Update the README accordingly
- [ ] Update the Vim documentation in `doc/test.txt`
