### PR TITLE
fix: make TestNearest search both directions for zig

### DIFF
--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -35,5 +35,8 @@ endfunction
 
 function! s:nearest_test(position) abort
   let name = test#base#nearest_test(a:position, g:test#zig#patterns)
+  if name.test_line == -1
+      let name = test#base#nearest_test_in_lines(a:position['file'], a:position['line'], line('$'), g:test#zig#patterns)
+  endif
   return test#base#escape_regex(join(name['test']))
 endfunction

--- a/spec/zig_spec.vim
+++ b/spec/zig_spec.vim
@@ -18,11 +18,18 @@ describe "Zig"
     Expect g:test#last_command == "zig test normal.zig"
   end
 
-  it "runs nearest test"
+  it "runs nearest test above"
     view +9 normal.zig
     TestNearest
 
     Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers 2'''
+  end
+
+  it "runs nearest test below"
+    view +1 normal.zig
+    TestNearest
+
+    Expect g:test#last_command == 'zig test normal.zig --test-filter ''numbers'''
   end
 
   it "runs all tests"


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`


I'm not sure if this is on anyone's wishlist, but I found it odd that `TestNearest` behaved like `TestFile` when there were no tests above the current line. This PR makes it run the nearest test _below_ in case it finds no tests upwards, which is what I'd expect from the _Nearest_ in the name, and if somebody actually wanted to run _all_ of the tests then there's `TestFile`.

This is now probably an inconsistency compared to other test runners, but I haven't used any of them so...

In any case, I'd rather have this closed (but not deleted) in case somebody has the same itch than not having it published anywhere at all.