### PR TITLE
fix: last test line index

### DIFF
--- a/autoload/test/base.vim
+++ b/autoload/test/base.vim
@@ -114,7 +114,6 @@ function! test#base#nearest_test_in_lines(filename, from_line, to_line, patterns
   let test         = []
   let namespace    = []
   let last_indent  = -1
-  let current_line = a:from_line + 1
   let test_line    = -1
   let last_namespace_line = -1
   let is_namespace_with_same_indent_allowed = get(configuration, 'namespaces_with_same_indent', 0)
@@ -126,8 +125,10 @@ function! test#base#nearest_test_in_lines(filename, from_line, to_line, patterns
     \ ? reverse(getbufline(l:filename, a:to_line, a:from_line))
     \ : getbufline(l:filename, a:from_line, a:to_line)
 
-  for line in lines
-    let current_line    = current_line + (is_reverse ? -1 : 1)
+  let i = 0
+  while i < len(lines)
+    let line = lines[i]
+    let current_line    = a:from_line + (is_reverse ? -1 : 1) * i
     let test_match      = s:find_match(line, a:patterns['test'])
     let namespace_match = s:find_match(line, a:patterns['namespace'])
 
@@ -152,7 +153,8 @@ function! test#base#nearest_test_in_lines(filename, from_line, to_line, patterns
       let last_indent = indent
       let last_namespace_line = current_line
     endif
-  endfor
+    let i += 1
+  endwhile
 
   return {'test': test, 'test_line': test_line, 'namespace': reverse(namespace)}
 endfunction

--- a/autoload/test/zig/zigtest.vim
+++ b/autoload/test/zig/zigtest.vim
@@ -8,11 +8,14 @@ endfunction
 
 function! test#zig#zigtest#build_position(type, position) abort
   if a:type ==# 'nearest'
-    let name = s:nearest_test(a:position)
-    if empty(name)
+    let test = s:nearest_test(a:position)
+    if test['test_line'] == -1
       return ['test', a:position['file']]
     endif
 
+    let name = test#base#escape_regex(join(test['test']))
+
+    let g:test#last_position['line'] = test['test_line']
     return ['test', a:position['file'],  '--test-filter '.shellescape(name, 1)]
   elseif a:type ==# 'file'
     return ['test', a:position['file']]
@@ -34,9 +37,9 @@ function! test#zig#zigtest#executable() abort
 endfunction
 
 function! s:nearest_test(position) abort
-  let name = test#base#nearest_test(a:position, g:test#zig#patterns)
-  if name.test_line == -1
-      let name = test#base#nearest_test_in_lines(a:position['file'], a:position['line'], line('$'), g:test#zig#patterns)
+  let test = test#base#nearest_test(a:position, g:test#zig#patterns)
+  if test.test_line == -1
+      let test = test#base#nearest_test_in_lines(a:position['file'], a:position['line'], line('$'), g:test#zig#patterns)
   endif
-  return test#base#escape_regex(join(name['test']))
+  return test
 endfunction

--- a/spec/zig_spec.vim
+++ b/spec/zig_spec.vim
@@ -38,4 +38,15 @@ describe "Zig"
 
     Expect g:test#last_command == "zig build test"
   end
+
+  it "update g:test#last_position with exact line of the test"
+    view +1 normal.zig
+    TestNearest
+
+    Expect g:test#last_position['line'] == 4
+
+    view +9 normal.zig
+    TestNearest
+
+    Expect g:test#last_position['line'] == 8
 end


### PR DESCRIPTION
Make sure these boxes are checked before submitting your pull request:

- [x] Add fixtures and spec when implementing or updating a test runner
- [x] Update the README accordingly
- [x] Update the Vim documentation in `doc/test.txt`

Without  the rewrite of the `for` loop there was an _off-by-two_ error when searching downwards.

Running just the tests without the fix in place:
```
-------- Testing a Vim plugin
spec/zig_spec.vim .. 1/?
not ok 5 - Zig update g:test#last_position with exact line of the test
# Expected g:test#last_position['line'] == 4 at line 4
#       Actual value: 6
#     Expected value: 4
spec/zig_spec.vim .. Failed 1/5 subtests

Test Summary Report
-------------------
spec/zig_spec.vim (Wstat: 0 Tests: 5 Failed: 1)
  Failed test:  5
Files=1, Tests=5,  1 wallclock secs ( 0.01 usr  0.00 sys +  0.05 cusr  0.04 csys =  0.10 CPU)
Result: FAIL
```

The `last_position['line']` is used in `test#visit` to jump to the place where the test was invoked _from_, but I think it makes more sense that `TestVisit` actually visits _the test it ran_.

In case the user ran `TestFile`, it won't update the `last_position['line']`.

~Note: the PR contains the PR #903 because it tests its new functionality (searching downwards) so that one should get merged first.~ Rebased!

Note: `TestVisit` for test runners other than `zig` will still exhibit the current behavior.