### PR TITLE
fix: escape spaces for busted --filter

### DIFF
--- a/autoload/test/lua/busted.vim
+++ b/autoload/test/lua/busted.vim
@@ -50,5 +50,5 @@ endfunction
 function! s:escape_lua_pattern(pattern) abort
   let magic_characters = ["(", ")", "\\.", "%", "+", "-", "*", "?", "[", "\\^", "\\$"]
   let magic_str = join(magic_characters, "\\|")
-  return substitute(a:pattern, "\\(" . magic_str . "\\)", "%\\1", "g")
+  return substitute(substitute(a:pattern, "\\(" . magic_str . "\\)", "%\\1", "g"), ' ', '\\ ', 'g')
 endfunction

--- a/spec/busted_spec.vim
+++ b/spec/busted_spec.vim
@@ -20,7 +20,7 @@ describe "LuaTest"
     view +2 normal_spec.lua
     TestNearest
 
-    Expect g:test#last_command == 'busted --filter ''can be added'' normal_spec.lua'
+    Expect g:test#last_command == 'busted --filter ''can\ be\ added'' normal_spec.lua'
 
     view normal_spec.moon
     TestNearest
@@ -30,14 +30,14 @@ describe "LuaTest"
     view +2 normal_spec.moon
     TestNearest
 
-    Expect g:test#last_command == 'busted --filter ''can be added'' normal_spec.moon'
+    Expect g:test#last_command == 'busted --filter ''can\ be\ added'' normal_spec.moon'
   end
 
   it "runs nearest tests and escapes Lua pattern magic characters"
     view +7 normal_spec.lua
     TestNearest
 
-    Expect g:test#last_command == 'busted --filter ''can add with magic \%( \%) \%. \%\% \%+ \%- \%* \%? \%[ \%^ \%$'' normal_spec.lua'
+    Expect g:test#last_command == 'busted --filter ''can\ add\ with\ magic\ \%(\ \%)\ \%.\ \%\%\ \%+\ \%-\ \%*\ \%?\ \%[\ \%^\ \%$'' normal_spec.lua'
   end
 
   it "runs file tests"


### PR DESCRIPTION
Ref: https://github.com/vim-test/vim-test/issues/908

Fixed busted to escape spaces for the `--filter` argument.

Updated `spec/busted_spec.vim` too.

> Note: `(` and `)` magic characters are still broken, other magic characters work fine.